### PR TITLE
Proposed patch to help in extending LittleProxy

### DIFF
--- a/src/main/java/org/littleshoot/proxy/DefaultRelayPipelineFactoryFactory.java
+++ b/src/main/java/org/littleshoot/proxy/DefaultRelayPipelineFactoryFactory.java
@@ -1,6 +1,7 @@
 package org.littleshoot.proxy;
 
 import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -8,10 +9,10 @@ import org.jboss.netty.handler.codec.http.HttpRequest;
 public class DefaultRelayPipelineFactoryFactory 
     implements RelayPipelineFactoryFactory {
     
-    private ChainProxyManager chainProxyManager;
-    private ChannelGroup channelGroup;
-    private HttpRequestFilter requestFilter;
-    private final HttpResponseFilters responseFilters;
+    protected ChainProxyManager chainProxyManager;
+    protected ChannelGroup channelGroup;
+    protected HttpRequestFilter requestFilter;
+    protected final HttpResponseFilters responseFilters;
 
     public DefaultRelayPipelineFactoryFactory(
         final ChainProxyManager chainProxyManager, 
@@ -24,19 +25,22 @@ public class DefaultRelayPipelineFactoryFactory
         this.requestFilter = requestFilter;
     }
     
+    @Override
     public ChannelPipelineFactory getRelayPipelineFactory(
         final HttpRequest httpRequest, final Channel browserToProxyChannel,
-        final RelayListener relayListener) {
+        final RelayListener relayListener, final ChannelHandlerContext ctx,
+        String hostAndPort) {
 	
-        String hostAndPort = chainProxyManager == null
-            ? null : chainProxyManager.getChainProxy(httpRequest);
-        if (hostAndPort == null) {
-            hostAndPort = ProxyUtils.parseHostAndPort(httpRequest);
-        }
-        
-        return new DefaultRelayPipelineFactory(hostAndPort, httpRequest, 
-            relayListener, browserToProxyChannel, channelGroup, responseFilters, 
-            requestFilter, chainProxyManager);
+        return getRelayPipelineFactory(httpRequest, 
+            browserToProxyChannel, relayListener, hostAndPort, ctx);
     }
     
+    protected DefaultRelayPipelineFactory getRelayPipelineFactory(
+              final HttpRequest httpRequest, final Channel browserToProxyChannel,
+              final RelayListener relayListener, final String hostAndPort,
+              final ChannelHandlerContext ctx) {
+        return new DefaultRelayPipelineFactory(hostAndPort, httpRequest,
+            relayListener, browserToProxyChannel, channelGroup, responseFilters,
+            requestFilter, chainProxyManager);
+    }
 }

--- a/src/main/java/org/littleshoot/proxy/HttpConnectRelayingHandler.java
+++ b/src/main/java/org/littleshoot/proxy/HttpConnectRelayingHandler.java
@@ -29,9 +29,9 @@ public class HttpConnectRelayingHandler extends SimpleChannelUpstreamHandler {
      * to the proxy or it could be a connection from the proxy to an external
      * site.
      */
-    private final Channel relayChannel;
+    protected final Channel relayChannel;
 
-    private final ChannelGroup channelGroup;
+    protected final ChannelGroup channelGroup;
 
     /**
      * Creates a new {@link HttpConnectRelayingHandler} with the specified 

--- a/src/main/java/org/littleshoot/proxy/ProxyHttpRequestEncoder.java
+++ b/src/main/java/org/littleshoot/proxy/ProxyHttpRequestEncoder.java
@@ -16,10 +16,10 @@ public class ProxyHttpRequestEncoder extends HttpRequestEncoder {
 
     private static final Logger LOG = 
         LoggerFactory.getLogger(ProxyHttpRequestEncoder.class);
-    private final HttpRelayingHandler relayingHandler;
-    private final HttpRequestFilter requestFilter;
-    private final boolean keepProxyFormat;
-    private final boolean transparent;
+    protected final HttpRelayingHandler relayingHandler;
+    protected final HttpRequestFilter requestFilter;
+    protected final boolean keepProxyFormat;
+    protected final boolean transparent;
 
     /**
      * Creates a new request encoder.

--- a/src/main/java/org/littleshoot/proxy/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/ProxyUtils.java
@@ -54,23 +54,19 @@ public class ProxyUtils {
     
     private static final Set<String> hopByHopHeaders = new HashSet<String>();
     
-    private static final String via;
-    private static final String hostName;
+    private static String via;
+    private static String viaDetails;
+    private static final String DEFAULT_VIA_VERSION = "1.1";
     
     static {
         try {
             final InetAddress localAddress = InetAddress.getLocalHost();
-            hostName = localAddress.getHostName();
+            setViaDetails(localAddress.getHostName());
         }
         catch (final UnknownHostException e) {
             LOG.error("Could not lookup host", e);
             throw new IllegalStateException("Could not determine host!", e);
         }
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Via: 1.1 ");
-        sb.append(hostName);
-        sb.append("\r\n");
-        via = sb.toString();
         
         //hopByHopHeaders.add("proxy-connection");
         hopByHopHeaders.add("connection");
@@ -85,7 +81,7 @@ public class ProxyUtils {
         //hopByHopHeaders.add("transfer-encoding");
         hopByHopHeaders.add("upgrade");
     }
-
+    
     /**
      * Utility class for a no-op {@link ChannelFutureListener}.
      */
@@ -511,8 +507,8 @@ public class ProxyUtils {
         sb.append(msg.getProtocolVersion().getMajorVersion());
         sb.append(".");
         sb.append(msg.getProtocolVersion().getMinorVersion());
-        sb.append(".");
-        sb.append(hostName);
+        sb.append(" ");
+        sb.append(viaDetails);
         final List<String> vias; 
         if (msg.containsHeader(HttpHeaders.Names.VIA)) {
             vias = msg.getHeaders(HttpHeaders.Names.VIA);
@@ -590,5 +586,21 @@ public class ProxyUtils {
 
 		return charset;
 	}
+    
+    public static String getViaDetails() {
+    	return viaDetails;
+    }
+    
+    public static void setViaDetails(String details) {
+    	viaDetails = details;
+    	
+    	final StringBuilder sb = new StringBuilder();
+        sb.append("Via: ");
+        sb.append(DEFAULT_VIA_VERSION);
+        sb.append(" ");
+        sb.append(details);
+        sb.append("\r\n");
+        via = sb.toString();
+    }
 
 }

--- a/src/main/java/org/littleshoot/proxy/RelayPipelineFactoryFactory.java
+++ b/src/main/java/org/littleshoot/proxy/RelayPipelineFactoryFactory.java
@@ -1,12 +1,14 @@
 package org.littleshoot.proxy;
 
 import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 
 public interface RelayPipelineFactoryFactory {
 
     ChannelPipelineFactory getRelayPipelineFactory(HttpRequest httpRequest, 
-        Channel browserToProxyChannel, RelayListener relayListener);
+        Channel browserToProxyChannel, RelayListener relayListener,
+        final ChannelHandlerContext ctx, String hostAndPort);
 
 }


### PR DESCRIPTION
Primary purpose of this commit was to extend LittleProxy through a dependent project. The project extends DefaultHttpProxyServer. Converted many fields from private to protected. Wrapped all object instantiations in a protected method. Both of these changes allow for subclasses to have access to state data and return other subclasses for the rest of the implementation. Added a few protected void callbacks in important parts of the code so that the subclass can do things like track the request flow. Also needed access to the default ProxyUtils.via, so made a get/set on that. There was also a bug where it appended a period after the Via minor version instead of a space.
