### PR TITLE
Follow up to issue #20: add ability to track requests that fail due to idle state

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpRequestHandler.java
+++ b/src/main/java/org/littleshoot/proxy/HttpRequestHandler.java
@@ -84,6 +84,8 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler
     private final Set<String> answeredRequests = new HashSet<String>();
     private final Set<String> unansweredRequests = new HashSet<String>();
 
+    private final Set<HttpRequest> unansweredHttpRequests = new HashSet<HttpRequest>();
+
     private ChannelFuture currentChannelFuture;
     
     private final ChainProxyManager chainProxyManager;
@@ -280,6 +282,7 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler
                             if (useJmx) {
                                 unansweredRequests.add(request.toString());
                             }
+                            unansweredHttpRequests.add(request);
                             requestsSent.incrementAndGet();
                         }
                     });
@@ -634,6 +637,7 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler
             this.answeredRequests.add(httpRequest.toString());
             this.unansweredRequests.remove(httpRequest.toString());
         }
+        this.unansweredHttpRequests.remove(httpRequest);
         this.unansweredRequestCount.decrementAndGet();
         this.responsesReceived.incrementAndGet();
         // If we've received responses to all outstanding requests and one
@@ -690,6 +694,10 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler
 
     public String getUnansweredRequests() {
         return this.unansweredRequests.toString();
+    }
+
+    public Set<HttpRequest> getUnansweredHttpRequests() {
+      return unansweredHttpRequests;
     }
 
     public String getAnsweredReqeusts() {

--- a/src/main/java/org/littleshoot/proxy/HttpServerPipelineFactory.java
+++ b/src/main/java/org/littleshoot/proxy/HttpServerPipelineFactory.java
@@ -230,13 +230,15 @@ public class HttpServerPipelineFactory implements ChannelPipelineFactory,
             pipeline.addLast("GLOBAL_TRAFFIC_SHAPING", trafficShaper);
         }
         */
+
+        HttpRequestHandler httpRequestHandler = new HttpRequestHandler(this.cacheManager, authenticationManager,
+            this.channelGroup, this.clientSocketChannelFactory,
+            this.chainProxyManager, relayPipelineFactoryFactory, this.useJmx);
         
         pipeline.addLast("idle", new IdleStateHandler(TIMER, 0, 0, 70));
-        pipeline.addLast("idleAware", new IdleAwareHandler("Client-Pipeline"));
-        pipeline.addLast("handler", 
-            new HttpRequestHandler(this.cacheManager, authenticationManager, 
-                this.channelGroup, this.clientSocketChannelFactory,
-                this.chainProxyManager, relayPipelineFactoryFactory, this.useJmx));
+        //pipeline.addLast("idleAware", new IdleAwareHandler("Client-Pipeline"));
+        pipeline.addLast("idleAware", new IdleRequestHandler(httpRequestHandler));
+        pipeline.addLast("handler", httpRequestHandler);
         this.numHandlers++;
         return pipeline;
     }

--- a/src/main/java/org/littleshoot/proxy/IdleHttpRequestException.java
+++ b/src/main/java/org/littleshoot/proxy/IdleHttpRequestException.java
@@ -1,0 +1,5 @@
+package org.littleshoot.proxy;
+
+public class IdleHttpRequestException extends RuntimeException {
+
+}

--- a/src/main/java/org/littleshoot/proxy/IdleRequestHandler.java
+++ b/src/main/java/org/littleshoot/proxy/IdleRequestHandler.java
@@ -1,0 +1,53 @@
+package org.littleshoot.proxy;
+
+import java.util.Set;
+
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.timeout.IdleStateEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+  * Idle handler that monitors requests that haven't resolved
+  * on browser to proxy connections.  Useful for debugging 
+  * slow requests.
+  */
+public class IdleRequestHandler extends IdleAwareHandler {
+
+  private HttpRequestHandler handler;
+
+  private static final Logger log =
+      LoggerFactory.getLogger(IdleRequestHandler.class);
+
+  public IdleRequestHandler(HttpRequestHandler handler) {
+    super("Client-Pipeline");
+    this.handler = handler;
+  }
+
+  @Override
+  public void channelIdle(ChannelHandlerContext ctx, IdleStateEvent e) {
+    super.channelIdle(ctx, e);
+    Set<HttpRequest> unansweredHttpRequests = handler.getUnansweredHttpRequests();
+    // If this isn't empty, we have requests paused
+    if (!unansweredHttpRequests.isEmpty()) {
+      StringBuilder message = new StringBuilder("The connection was terminated before resolving the following resources:\n");
+      for (HttpRequest unansweredRequest : unansweredHttpRequests) {
+        // Go through each unanswered request and concat the info 
+        message.append(unansweredRequest.getUri());
+        String referrer = unansweredRequest.getHeader("Referer");
+        if (!isEmpty(referrer)) {
+          // Capure the referrer so that slow resources can be tracked to a page
+          message.append(" from ").append(referrer);
+        }
+        message.append("\n");
+      }
+      // Log all of the requests that failed
+      log.error(message.toString(), new IdleHttpRequestException());
+    }
+  }
+
+  private boolean isEmpty(String value) {
+    return value == null || value.isEmpty();
+  }
+}


### PR DESCRIPTION
In order to track down slow resources on a page, these changes log any
requests that have hit an idle status on browser to proxy connections,
along with the referrer to figure out what pages may have slow
resources.

I've run this change on a local build in a relatively high load setting and didn't see any issues.  However, I made the changes on an SVN repo that I have access to and had to do some hand merging to get them onto Github.  I think everything should be in order.  There is 1 unit test failing, but it also fails when I check out your master copy, so I'm guessing it's unrelated to my changes.

Thanks for the awesome proxy server :)
