### PR TITLE
Make dependencies on log4j optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.16</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -147,6 +148,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.6.1</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
...so that users of LittleProxy can pick their favourite logging library.
