### PR TITLE
Upgrading to Latest Commons Lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/littleshoot/proxy/DefaultProxyAuthorizationManager.java
+++ b/src/main/java/org/littleshoot/proxy/DefaultProxyAuthorizationManager.java
@@ -6,7 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.slf4j.Logger;

--- a/src/main/java/org/littleshoot/proxy/DefaultProxyCacheManager.java
+++ b/src/main/java/org/littleshoot/proxy/DefaultProxyCacheManager.java
@@ -8,7 +8,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.http.HttpHeaders;

--- a/src/main/java/org/littleshoot/proxy/HttpRelayingHandler.java
+++ b/src/main/java/org/littleshoot/proxy/HttpRelayingHandler.java
@@ -3,7 +3,7 @@ package org.littleshoot.proxy;
 import java.util.LinkedList;
 import java.util.Queue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;

--- a/src/main/java/org/littleshoot/proxy/HttpRequestHandler.java
+++ b/src/main/java/org/littleshoot/proxy/HttpRequestHandler.java
@@ -22,7 +22,7 @@ import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.netty.bootstrap.ClientBootstrap;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;

--- a/src/main/java/org/littleshoot/proxy/IdleRequestHandler.java
+++ b/src/main/java/org/littleshoot/proxy/IdleRequestHandler.java
@@ -2,7 +2,7 @@ package org.littleshoot.proxy;
 
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.timeout.IdleStateEvent;

--- a/src/main/java/org/littleshoot/proxy/Launcher.java
+++ b/src/main/java/org/littleshoot/proxy/Launcher.java
@@ -9,7 +9,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.cli.UnrecognizedOptionException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/littleshoot/proxy/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/ProxyUtils.java
@@ -17,8 +17,8 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;

--- a/src/main/java/org/littleshoot/proxy/RegexHttpRequestFilter.java
+++ b/src/main/java/org/littleshoot/proxy/RegexHttpRequestFilter.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 
 /**

--- a/src/test/java/org/littleshoot/proxy/HttpProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpProxyTest.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;


### PR DESCRIPTION
We are Dependent on LittleProxy  in Selenium Project , i am upgrading htmlunit drivers from (htmlunit 4.9 to 4.10) which uses commons-lang3 
