### PR TITLE
Add support for ProxyCacheManager to be set in the properties

### DIFF
--- a/src/main/java/org/littleshoot/proxy/LittleProxyConfig.java
+++ b/src/main/java/org/littleshoot/proxy/LittleProxyConfig.java
@@ -47,6 +47,9 @@ public class LittleProxyConfig {
     private static boolean useJmx = 
         ProxyUtils.extractBooleanDefaultFalse(props, "jmx");
     
+    private static String proxyCacheManagerClass = 
+        props.getProperty("proxy_cache_manager_class");
+    
     private LittleProxyConfig(){}
 
     /**
@@ -86,5 +89,13 @@ public class LittleProxyConfig {
      */
     public static boolean isUseJmx() {
         return useJmx;
+    }
+    
+    public static void setProxyCacheManagerClass(String clazz) {
+        proxyCacheManagerClass = clazz;
+    }
+    
+    public static String getProxyCacheManagerClass() {
+        return proxyCacheManagerClass;
     }
 }

--- a/src/test/java/org/littleshoot/proxy/HttpProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpProxyTest.java
@@ -21,7 +21,10 @@ import java.net.UnknownHostException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
@@ -117,7 +120,7 @@ public class HttpProxyTest {
         
         try {
             final String response =
-                httpPostWithApacheClient(true, "http://kt.baidu.com");
+                httpPostWithApacheClient(true, "http://test.localhost");
             assertTrue(response.startsWith("Bad Gateway"));
         } finally {
             server.stop();
@@ -157,6 +160,24 @@ public class HttpProxyTest {
         } finally {
             server.stop();
         }
+    }
+    
+    @Test
+    public void testConfiguredProxyCacheManager() throws IOException {
+        LittleProxyConfig.setProxyCacheManagerClass( SimpleProxyCacheManager.class.getCanonicalName() );
+        final HttpProxyServer server =  startHttpProxy();
+        // clear the test manager from config, so it does not bleed into other tests
+        LittleProxyConfig.setProxyCacheManagerClass( null );
+        
+        try {
+            String baseResponse = httpPostWithApacheClient(false);
+            String proxyResponse = httpPostWithApacheClient(true);
+            assertEquals(baseResponse, proxyResponse);
+        } finally {
+            server.stop();
+        }
+        
+        assertEquals( Arrays.asList("http://opsgenie.com/status/ping"), SimpleProxyCacheManager.requests );
     }
 
     private String httpPostWithApacheClient(final boolean isProxy) 
@@ -485,5 +506,6 @@ public class HttpProxyTest {
         }
     }
 }
+
 
 

--- a/src/test/java/org/littleshoot/proxy/SimpleProxyCacheManager.java
+++ b/src/test/java/org/littleshoot/proxy/SimpleProxyCacheManager.java
@@ -1,0 +1,29 @@
+package org.littleshoot.proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+class SimpleProxyCacheManager implements ProxyCacheManager {
+
+    public static final List<String> requests = new ArrayList<String>();
+    
+    public boolean returnCacheHit(HttpRequest request, Channel channel) {
+        
+        requests.add( request.getUri() );
+        
+        return false;
+    }
+
+    public Future<String> cache(HttpRequest originalRequest,
+            org.jboss.netty.handler.codec.http.HttpResponse httpResponse,
+            Object response, ChannelBuffer encoded) {
+        
+        return null;
+    }
+    
+}


### PR DESCRIPTION
Added support for ProxyCacheManager to by adding proxy_cache_manager_class to the properties.

Also updated HttpProxyTest#testProxyWithApacheHttpClientChunkedRequestsBadAddress to fail fast by using test.localhost instead of kr.baidu.com. The kr.baidu.com domain was time outing for me.
