### PR TITLE
Make sure that idle handler also catches connections which are idle for both reading and writing

### DIFF
--- a/src/main/java/org/littleshoot/proxy/IdleAwareHandler.java
+++ b/src/main/java/org/littleshoot/proxy/IdleAwareHandler.java
@@ -35,6 +35,9 @@ public class IdleAwareHandler extends ChannelDuplexHandler {
         } else if (idleState == IdleState.WRITER_IDLE) {
             log.info("Got writer idle -- closing connection -- " + this);
             ctx.channel().close();
+        } else if (idleState == IdleState.ALL_IDLE) {
+            log.info("Got all idle -- closing connection -- " + this);
+            ctx.channel().close();
         }
     }
 


### PR DESCRIPTION
This fixes problem of stale connections not getting closed after timeout.
