### PR TITLE
fix incorrect behaviour DefaultHttpProxyServer for persistent connection

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpRelayingHandler.java
+++ b/src/main/java/org/littleshoot/proxy/HttpRelayingHandler.java
@@ -13,6 +13,7 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.HttpMethod;
 
 import java.util.LinkedList;
 import java.util.Queue;
@@ -542,5 +543,9 @@ public class HttpRelayingHandler extends SimpleChannelInboundHandler<HttpObject>
             }
         }
     }
-    
+
+    public HttpMethod getMethodFromRequest() {
+        return requestQueue.peek().getMethod();
+    }
+
 }

--- a/src/main/java/org/littleshoot/proxy/ProxyHttpResponseDecoder.java
+++ b/src/main/java/org/littleshoot/proxy/ProxyHttpResponseDecoder.java
@@ -1,0 +1,53 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.HttpResponseDecoder;
+
+
+public class  ProxyHttpResponseDecoder extends HttpResponseDecoder {
+    private HttpRelayingHandler relayingHandler;
+
+    /**
+     * Creates a new instance with the default
+     * {@code maxInitialLineLength (4096}}, {@code maxHeaderSize (8192)}, and
+     * {@code maxChunkSize (8192)}.
+     */
+    public ProxyHttpResponseDecoder() {
+        super();
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     */
+    public ProxyHttpResponseDecoder(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, HttpRelayingHandler handler) {
+        super(maxInitialLineLength, maxHeaderSize, maxChunkSize);
+        this.relayingHandler = handler;
+    }
+
+    @Override
+    protected HttpMessage createMessage(String[] initialLine) {
+        return new DefaultHttpResponse(
+                HttpVersion.valueOf(initialLine[0]),
+                new HttpResponseStatus(Integer.valueOf(initialLine[1]), initialLine[2]));
+    }
+
+    @Override
+    protected boolean isDecodingRequest() {
+        return false;
+    }
+
+    @Override
+    protected boolean isContentAlwaysEmpty(HttpMessage msg) {
+        HttpMethod method = relayingHandler.getMethodFromRequest();
+        if (method == HttpMethod.HEAD) {
+            return true;
+        }
+        return super.isContentAlwaysEmpty(msg);
+    }
+}
+


### PR DESCRIPTION
DefaultRelayChannelInitializer sets HttpResponseDecoder and override method isContentAlwaysEmpty() for it.
That is good for single connection, but there is problem for persistent connection, because if first request has HEAD method, and next request is GET, method isContentAlwaysEmpty() returned true also for it, and decoder works wrong.
