### PR TITLE
Typo for javadoc

### DIFF
--- a/src/main/java/org/littleshoot/proxy/MitmManager.java
+++ b/src/main/java/org/littleshoot/proxy/MitmManager.java
@@ -9,7 +9,7 @@ import javax.net.ssl.SSLSession;
  */
 public interface MitmManager {
     /**
-     * Creates an {link SSLEngine} for encrypting the server connection.
+     * Creates an {@link SSLEngine} for encrypting the server connection.
      * 
      * @return
      */


### PR DESCRIPTION
Missing an at sign.
