### PR TITLE
Usage example code updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,37 +37,32 @@ HttpProxyServer server =
     DefaultHttpProxyServer.bootstrap()
         .withPort(8080)
         .withFiltersSource(new HttpFiltersSourceAdapter() {
-            public HttpFilters filterRequest(HttpRequest originalRequest) {
-                // Check the originalRequest to see if we want to filter it
-                boolean wantToFilterRequest = ...;
-                
-                if (!wantToFilterRequest) {
-                    return null;
-                } else {
-                    return new HttpFiltersAdapter(originalRequest) {
-                        @Override
-                        public HttpResponse requestPre(HttpObject httpObject) {
-                            // TODO: implement your filtering here
-                            return null;
-                        }
-                    
-                        @Override
-                        public HttpResponse requestPost(HttpObject httpObject) {
-                            // TODO: implement your filtering here
-                            return null;
-                        }
-                    
-                        @Override
-                        public void responsePre(HttpObject httpObject) {
-                            // TODO: implement your filtering here
-                        }
-                    
-                        @Override
-                        public void responsePost(HttpObject httpObject) {
-                            // TODO: implement your filtering here
-                        }   
-                    };
-                }
+            public HttpFilters filterRequest(HttpRequest originalRequest, ChannelHandlerContext ctx) {
+               return new HttpFiltersAdapter(originalRequest) {
+                  @Override
+                  public HttpResponse requestPre(HttpObject httpObject) {
+                      // TODO: implement your filtering here
+                      return null;
+                  }
+
+                  @Override
+                  public HttpResponse requestPost(HttpObject httpObject) {
+                      // TODO: implement your filtering here
+                      return null;
+                  }
+
+                  @Override
+                  public HttpObject responsePre(HttpObject httpObject) {
+                      // TODO: implement your filtering here
+                      return httpObject;
+                  }
+
+                  @Override
+                  public HttpObject responsePost(HttpObject httpObject) {
+                      // TODO: implement your filtering here
+                      return httpObject;
+                  }   
+               };
             }
         })
         .start();


### PR DESCRIPTION
My changes to the project were mostly Android specific. I didn't want to include Apache commons libraries in my project, so I wrote manually those few functions from StringUtils and IOUtils and so on. Same thing with the slf4j logger, I converted it to use Android's built in logger. You had also UDT protocl supported, but it requested some external files so I commented those out since I didn't need to support UDT.

For some reason line 768 in ProxyToServerConnection.java didn't know class VerifiedAddressFactory, so I needed to comment that out. Something to do with DnsSec.

But here's the fixed README. 
1. filterRequest without ChannelHandlerContext parameter wasn't never called.
2. If filterRequest returns null, it produces a NPE in ClientToProxyConnection.java line 197.
3. HttpFiltersAdapter responsePre and responsePost should return HttpObject.
