### PR TITLE
NTLM support for chained proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
       <groupId>jcifs</groupId>
       <artifactId>jcifs</artifactId>
       <version>1.3.17</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>servlet-api</artifactId>
+          <groupId>javax.servlet</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
       <version>4.0.14.Final</version>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>jcifs</groupId>
+      <artifactId>jcifs</artifactId>
+      <version>1.3.17</version>
+    </dependency>
     
     <dependency>
       <groupId>com.barchart.udt</groupId>

--- a/src/main/java/org/littleshoot/proxy/ChainedProxy.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxy.java
@@ -4,6 +4,8 @@ import io.netty.handler.codec.http.HttpObject;
 
 import java.net.InetSocketAddress;
 
+import org.littleshoot.proxy.ntlm.NtlmHandler;
+
 /**
  * <p>
  * Encapsulates information needed to connect to a chained proxy.
@@ -14,7 +16,7 @@ import java.net.InetSocketAddress;
  * defaults.
  * </p>
  */
-public interface ChainedProxy extends SslEngineSource {
+public interface ChainedProxy extends SslEngineSource, NtlmHandler {
     /**
      * Return the {@link InetSocketAddress} for connecting to the chained proxy.
      * Returning null indicates that we won't chain.
@@ -48,6 +50,14 @@ public interface ChainedProxy extends SslEngineSource {
      * @return true of the connection to the chained proxy should be encrypted
      */
     boolean requiresEncryption();
+
+    /**
+     * Implement this method to tell LittleProxy whether or not to do preemptive
+     * NTLM authentication to the chained proxy.
+     *
+     * @return true to do NTLM handshake
+     */
+    boolean requiresNtlmAuthentication();
 
     /**
      * Filters requests on their way to the chained proxy.

--- a/src/main/java/org/littleshoot/proxy/ChainedProxy.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxy.java
@@ -16,7 +16,7 @@ import org.littleshoot.proxy.ntlm.NtlmHandler;
  * defaults.
  * </p>
  */
-public interface ChainedProxy extends SslEngineSource, NtlmHandler {
+public interface ChainedProxy extends SslEngineSource {
     /**
      * Return the {@link InetSocketAddress} for connecting to the chained proxy.
      * Returning null indicates that we won't chain.
@@ -51,13 +51,16 @@ public interface ChainedProxy extends SslEngineSource, NtlmHandler {
      */
     boolean requiresEncryption();
 
-    /**
-     * Implement this method to tell LittleProxy whether or not to do preemptive
-     * NTLM authentication to the chained proxy.
+   /**
+     * Tell LittleProxy whether or not to do preemptive NTLM authentication to
+     * the chained proxy. Same instance should be returned to maintain state
+     * during NLTM handshake.
      *
-     * @return true to do NTLM handshake
+     * null indicates that we won't do NTLM handshake.
+     *
+     * @return NtlmHandler
      */
-    boolean requiresNtlmAuthentication();
+    NtlmHandler getNtlmHandler();
 
     /**
      * Filters requests on their way to the chained proxy.

--- a/src/main/java/org/littleshoot/proxy/ChainedProxyAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxyAdapter.java
@@ -1,8 +1,6 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.HttpObject;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
 
 import java.net.InetSocketAddress;
 
@@ -19,8 +17,6 @@ public class ChainedProxyAdapter implements ChainedProxy {
      * connection to the upstream server.
      */
     public static ChainedProxy FALLBACK_TO_DIRECT_CONNECTION = new ChainedProxyAdapter();
-
-    private NtlmHandler ntlmHandler;
 
     @Override
     public InetSocketAddress getChainedProxyAddress() {
@@ -43,8 +39,8 @@ public class ChainedProxyAdapter implements ChainedProxy {
     }
 
     @Override
-    public boolean requiresNtlmAuthentication() {
-        return ntlmHandler != null;
+    public NtlmHandler getNtlmHandler() {
+        return null;
     }
 
     @Override
@@ -66,25 +62,6 @@ public class ChainedProxyAdapter implements ChainedProxy {
 
     @Override
     public void disconnected() {
-    }
-
-    public void setNtlmMessageHandler(NtlmHandler handler) {
-        ntlmHandler = handler;
-    }
-
-    @Override
-    public void writeType1Header(HttpRequest httpRequest) {
-        ntlmHandler.writeType1Header(httpRequest);
-    }
-
-    @Override
-    public void readType2Header(HttpResponse httpResponse) throws Exception {
-        ntlmHandler.readType2Header(httpResponse);
-    }
-
-    @Override
-    public void writeType3Header(HttpRequest httpRequest) {
-        ntlmHandler.writeType3Header(httpRequest);
     }
 
 }

--- a/src/main/java/org/littleshoot/proxy/ChainedProxyAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxyAdapter.java
@@ -1,10 +1,14 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
 
 import java.net.InetSocketAddress;
 
 import javax.net.ssl.SSLEngine;
+
+import org.littleshoot.proxy.ntlm.NtlmHandler;
 
 /**
  * Convenience base class for implementations of {@link ChainedProxy}.
@@ -15,6 +19,8 @@ public class ChainedProxyAdapter implements ChainedProxy {
      * connection to the upstream server.
      */
     public static ChainedProxy FALLBACK_TO_DIRECT_CONNECTION = new ChainedProxyAdapter();
+
+    private NtlmHandler ntlmHandler;
 
     @Override
     public InetSocketAddress getChainedProxyAddress() {
@@ -37,6 +43,11 @@ public class ChainedProxyAdapter implements ChainedProxy {
     }
 
     @Override
+    public boolean requiresNtlmAuthentication() {
+        return ntlmHandler != null;
+    }
+
+    @Override
     public SSLEngine newSslEngine() {
         return null;
     }
@@ -56,4 +67,24 @@ public class ChainedProxyAdapter implements ChainedProxy {
     @Override
     public void disconnected() {
     }
+
+    public void setNtlmMessageHandler(NtlmHandler handler) {
+        ntlmHandler = handler;
+    }
+
+    @Override
+    public void writeType1Header(HttpRequest httpRequest) {
+        ntlmHandler.writeType1Header(httpRequest);
+    }
+
+    @Override
+    public void readType2Header(HttpResponse httpResponse) throws Exception {
+        ntlmHandler.readType2Header(httpResponse);
+    }
+
+    @Override
+    public void writeType3Header(HttpRequest httpRequest) {
+        ntlmHandler.writeType3Header(httpRequest);
+    }
+
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
@@ -12,6 +12,11 @@ enum ConnectionState {
     HANDSHAKING(true),
 
     /**
+     * In the process of waiting for NTLM Type2 response.
+     */
+    NTLM_HANDSHAKING(true),
+
+    /**
      * In the process of negotiating an HTTP CONNECT from the client.
      */
     NEGOTIATING_CONNECT(true),

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.udt.nio.NioUdtProvider;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
@@ -19,6 +20,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.Future;
@@ -472,6 +474,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                     .newSslEngine()));
         }
 
+        if (chainedProxy != null && chainedProxy.requiresNtlmAuthentication()) {
+            connectionFlow.then(serverConnection.NtlmWithChainedProxy);
+        }
+
         if (ProxyUtils.isCONNECT(initialRequest)) {
             MitmManager mitmManager = proxyServer.getMitmManager();
             boolean isMitmEnabled = mitmManager != null;
@@ -553,6 +559,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         protected Future<?> execute() {
             LOG.debug("Handling CONNECT request through Chained Proxy");
             chainedProxy.filterRequest(initialRequest);
+            if (chainedProxy.requiresNtlmAuthentication()) {
+                chainedProxy.writeType3Header(initialRequest);
+            }
+            issuedRequests.add(initialRequest);
             return writeToChannel(initialRequest);
         }
 
@@ -579,6 +589,50 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             }
         }
     };
+
+    private ConnectionFlowStep NtlmWithChainedProxy = new ConnectionFlowStep(this, NTLM_HANDSHAKING) {
+
+        protected Future<?> execute() {
+            HttpRequest request = copyAsFull(initialRequest);
+            chainedProxy.writeType1Header(request);
+            issuedRequests.add(request);
+            LOG.debug("Type1 message to NTLM chained proxy {}", request);
+            return writeToChannel(request);
+        }
+
+        void onSuccess(ConnectionFlow flow) {
+            // Do nothing, since we want to wait for the Type-2 response to come back
+        }
+
+        void read(ConnectionFlow flow, Object msg) {
+            // Here we're setting Type-2 response from a chained proxy
+            LOG.debug("Type2 message from NTLM chained proxy {}", msg);
+            if (msg instanceof HttpResponse) {
+                HttpResponse httpResponse = (HttpResponse) msg;
+                try {
+                    chainedProxy.readType2Header(httpResponse);
+                } catch (Exception e) {
+                    LOG.warn("Failed to handle NTLM Type2 message", e);
+                    flow.fail();
+                }
+			}
+
+            if (msg instanceof LastHttpContent) {
+                LOG.debug("Completed reading NTLM Type2 message");
+                flow.advance();
+                return;
+            }
+
+            // We are only interested in headers, not content
+            if (msg instanceof HttpContent) {
+                LOG.debug("Ignoring NTLM Type2 {}", msg);
+            }
+        }
+    };
+
+    private static HttpRequest copyAsFull(HttpRequest origin) {
+        return new DefaultFullHttpRequest(origin.getProtocolVersion(), origin.getMethod(), origin.getUri());
+    }
 
     /**
      * <p>
@@ -735,6 +789,9 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 shouldForwardInitialRequest);
 
         if (shouldForwardInitialRequest) {
+            if (chainedProxy != null && chainedProxy.requiresNtlmAuthentication()) {
+                chainedProxy.writeType3Header(initialRequest);
+            }
             LOG.debug("Writing initial request: {}", initialRequest);
             write(initialRequest);
         } else {

--- a/src/main/java/org/littleshoot/proxy/ntlm/JcifsNtlmProvider.java
+++ b/src/main/java/org/littleshoot/proxy/ntlm/JcifsNtlmProvider.java
@@ -29,15 +29,15 @@ public class JcifsNtlmProvider implements NtlmProvider {
 	private Type2Message type2;
 
 	public JcifsNtlmProvider(int flags, String user, String password, String domain, String workstation) {
-		this.flags = flags > 0 ? flags: getDefaultFlags();
+		this.flags = flags > 0 ? flags : getDefaultFlags();
 		this.user = checkNotNull(user);
 		this.password = checkNotNull(password);
 		this.domain = checkNotNull(domain);
 		this.workstation = checkNotNull(workstation);
 	}
 
-	public JcifsNtlmProvider(String username, String password) {
-		this(getDefaultFlags(), username, password, EMPTY, EMPTY);
+	public JcifsNtlmProvider(String user, String password, String domain) {
+		this(0, user, password, domain, EMPTY);
 	}
 
 	@Override

--- a/src/main/java/org/littleshoot/proxy/ntlm/JcifsNtlmProvider.java
+++ b/src/main/java/org/littleshoot/proxy/ntlm/JcifsNtlmProvider.java
@@ -1,0 +1,64 @@
+package org.littleshoot.proxy.ntlm;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static jcifs.ntlmssp.Type3Message.getDefaultFlags;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+import java.io.IOException;
+
+import jcifs.ntlmssp.NtlmMessage;
+import jcifs.ntlmssp.Type1Message;
+import jcifs.ntlmssp.Type2Message;
+import jcifs.ntlmssp.Type3Message;
+
+/**
+ * Reference implementation of {@link NtlmProvider}
+ */
+public class JcifsNtlmProvider implements NtlmProvider {
+
+	private final int flags;
+
+	private final String user;
+
+	private final String password;
+
+	private final String domain;
+
+	private final String workstation;
+
+	private Type2Message type2;
+
+	public JcifsNtlmProvider(int flags, String user, String password, String domain, String workstation) {
+		this.flags = flags > 0 ? flags: getDefaultFlags();
+		this.user = checkNotNull(user);
+		this.password = checkNotNull(password);
+		this.domain = checkNotNull(domain);
+		this.workstation = checkNotNull(workstation);
+	}
+
+	public JcifsNtlmProvider(String username, String password) {
+		this(getDefaultFlags(), username, password, EMPTY, EMPTY);
+	}
+
+	@Override
+	public byte[] getType1() {
+		NtlmMessage type1 = new Type1Message(flags, padRight(domain, 32), padRight(workstation, 8));
+		return type1.toByteArray();
+	}
+
+	@Override
+	public void setType2(byte[] material) throws IOException {
+		type2 = new Type2Message(material);
+	}
+
+	@Override
+	public byte[] getType3() {
+		NtlmMessage type3 = new Type3Message(type2, password, domain, user, workstation, type2.getFlags());
+		return type3.toByteArray();
+	}
+
+	private static String padRight(String s, int n) {
+		return String.format("%0$-" + n + "s", s);
+	}
+
+}

--- a/src/main/java/org/littleshoot/proxy/ntlm/NtlmHandler.java
+++ b/src/main/java/org/littleshoot/proxy/ntlm/NtlmHandler.java
@@ -1,0 +1,21 @@
+package org.littleshoot.proxy.ntlm;
+
+import org.littleshoot.proxy.ChainedProxy;
+
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+
+/**
+ * This serves as an extension to {@link ChainedProxy} which requires NTLM
+ * authentication. Implementation should set Type1 and Type3 Proxy-Authorization
+ * headers to the request.
+ */
+public interface NtlmHandler {
+
+	void writeType1Header(HttpRequest httpRequest);
+
+	void readType2Header(HttpResponse httpResponse) throws Exception;
+
+	void writeType3Header(HttpRequest httpRequest);
+
+}

--- a/src/main/java/org/littleshoot/proxy/ntlm/NtlmHandlerImpl.java
+++ b/src/main/java/org/littleshoot/proxy/ntlm/NtlmHandlerImpl.java
@@ -1,0 +1,71 @@
+package org.littleshoot.proxy.ntlm;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.netty.handler.codec.http.HttpHeaders.Names.PROXY_AUTHENTICATE;
+import static io.netty.handler.codec.http.HttpHeaders.Names.PROXY_AUTHORIZATION;
+import static io.netty.handler.codec.http.HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+
+import java.io.IOException;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is responsible for writing and reading NTLM related request and
+ * response headers respectively. It delegates the creating of NTLM messages to
+ * a provider.
+ */
+public class NtlmHandlerImpl implements NtlmHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(NtlmHandlerImpl.class);
+
+	private final NtlmProvider provider;
+
+	private boolean type2Done;
+
+	public NtlmHandlerImpl(NtlmProvider provider) {
+		this.provider = provider;
+	}
+
+	@Override
+	public void writeType1Header(HttpRequest httpRequest) {
+		checkState(!type2Done, "NTLM Type2 shouldn't have been set yet!");
+		byte[] type1 = provider.getType1();
+		setAuthHeader(httpRequest, type1);
+		LOG.debug("Set NTLM Type1 header");
+	}
+
+	@Override
+	public void readType2Header(HttpResponse httpResponse) throws IOException {
+		checkState(httpResponse.getStatus().equals(PROXY_AUTHENTICATION_REQUIRED), "No authentication challenge!");
+		String proxyAuth = httpResponse.headers().get(PROXY_AUTHENTICATE);
+		checkState(proxyAuth.startsWith("NTLM"), "Authentication challenge is %s!", proxyAuth);
+		if (httpResponse.headers().contains("Proxy-Connection")) {
+			checkState(!httpResponse.headers().get("Proxy-Connection").equalsIgnoreCase("close"), "Proxy-Connection closed!");
+		}
+
+		checkState(!type2Done, "NTLM Type2 shouldn't have been set yet!");
+
+		String authChallenge = StringUtils.substringAfter(proxyAuth, "NTLM ");
+		provider.setType2(Base64.decodeBase64(authChallenge));
+		type2Done = true;
+		LOG.debug("Got NTLM Type2 header");
+	}
+
+	@Override
+	public void writeType3Header(HttpRequest httpRequest) {
+		checkState(type2Done, "NTLM Type2 should have been set by now!");
+		byte[] type3 = provider.getType3();
+		setAuthHeader(httpRequest, type3);
+		LOG.debug("Set NTLM Type3 header");
+	}
+
+	private static void setAuthHeader(HttpRequest httpRequest, byte[] msg) {
+		httpRequest.headers().set(PROXY_AUTHORIZATION, "NTLM " + Base64.encodeBase64String(msg));
+	}
+
+}

--- a/src/main/java/org/littleshoot/proxy/ntlm/NtlmProvider.java
+++ b/src/main/java/org/littleshoot/proxy/ntlm/NtlmProvider.java
@@ -1,0 +1,17 @@
+package org.littleshoot.proxy.ntlm;
+
+import java.io.IOException;
+
+/**
+ * Implementation should generate Type1 and Type3 messages, most probably using
+ * some library. Refer reference implementation {@link JcifsNtlmProvider}
+ */
+public interface NtlmProvider {
+
+	byte[] getType1();
+
+	void setType2(byte[] material) throws IOException;
+
+	byte[] getType3();
+
+}

--- a/src/test/java/org/littleshoot/proxy/AbstractProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/AbstractProxyTest.java
@@ -326,6 +326,9 @@ public abstract class AbstractProxyTest {
         if (isHTTPS && !isChained()) {
             numberOfExpectedServerInteractions -= 1;
         }
+        if(isChainedNTLM()) {
+            numberOfExpectedServerInteractions += 1;
+        }
         assertTrue(bytesReceivedFromClient.get() > 0);
         assertEquals(numberOfExpectedClientInteractions,
                 requestsReceivedFromClient.get());
@@ -355,6 +358,10 @@ public abstract class AbstractProxyTest {
     }
 
     protected boolean isMITM() {
+        return false;
+    }
+
+    protected boolean isChainedNTLM() {
         return false;
     }
 

--- a/src/test/java/org/littleshoot/proxy/NtlmChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/NtlmChainedProxyTest.java
@@ -1,0 +1,81 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.HttpRequest;
+
+import java.net.InetSocketAddress;
+import java.util.Queue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.littleshoot.proxy.ntlm.JcifsNtlmProvider;
+import org.littleshoot.proxy.ntlm.NtlmHandler;
+import org.littleshoot.proxy.ntlm.NtlmHandlerImpl;
+
+/**
+ * Test NTLM authentication to chained proxy. Since LittleProxy cannot verify
+ * NTLM credentials, chained proxy supporting NTLM authentication (e.g.
+ * FreeProxy) needs to be run explicitly.
+ */
+public class NtlmChainedProxyTest extends BaseProxyTest {
+
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress("127.0.0.1", 8080);
+	private static final String USERNAME = System.getProperty("user.name");
+	private static final String PASSWORD = "xxxxx";
+	private static final String DOMAIN = "";
+
+	private class NtlmChainedProxy extends ChainedProxyAdapter {
+
+		private final NtlmHandler handler = new NtlmHandlerImpl(new JcifsNtlmProvider(USERNAME, PASSWORD, DOMAIN));
+
+		@Override
+		public InetSocketAddress getChainedProxyAddress() {
+			return ADDRESS;
+		}
+
+		@Override
+		public NtlmHandler getNtlmHandler() {
+			return handler;
+		}
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		proxyServer = bootstrapProxy().withName("Downstream").withPort(proxyServerPort).withChainProxyManager(new ChainedProxyManager() {
+			@Override
+			public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies) {
+				chainedProxies.add(newChainedProxy());
+			}
+		}).start();
+
+	}
+
+	protected ChainedProxy newChainedProxy() {
+		return new NtlmChainedProxy();
+	}
+
+	@Override
+	protected boolean isChained() {
+		return true;
+	}
+
+	@Override
+	protected boolean isChainedNTLM() {
+		return true;
+	}
+
+	@Ignore
+	@Test
+	public void testProxyWithBadAddress() {
+	}
+
+	@Ignore
+	@Test
+	public void testSimplePostRequest() {
+	}
+
+	@Ignore
+	@Test
+	public void testHeadRequestFollowedByGet() {
+	}
+
+}


### PR DESCRIPTION
This is code proposal for LittleProxy to support preemptive NTLM authentication to a chained proxy.
In the class extending ChainedProxyAdapter, just set an NTLM handler to enable this feature.

setNtlmMessageHandler(new NtlmHandlerImpl(new JcifsNtlmProvider("myuser", "mypass")));

I have used http://jcifs.samba.org/ as default provider to generate NTLM messages, but any provider can be plugged in.
