### PR TITLE
added feature issue #135 interface binding

### DIFF
--- a/src/main/java/org/littleshoot/proxy/DefaultHostResolver.java
+++ b/src/main/java/org/littleshoot/proxy/DefaultHostResolver.java
@@ -2,7 +2,10 @@ package org.littleshoot.proxy;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
+
+import org.littleshoot.proxy.common.Constants;
 
 /**
  * Default implementation of {@link HostResolver} that just uses
@@ -15,4 +18,16 @@ public class DefaultHostResolver implements HostResolver {
         InetAddress addr = InetAddress.getByName(host);
         return new InetSocketAddress(addr, port);
     }
+    
+    @Override
+	public InetSocketAddress resolveLocalAddr()
+			throws SocketException {
+		InetSocketAddress isaLocal = null;
+		
+		if ( Constants.NICIP != null ) {
+			isaLocal = new InetSocketAddress(Constants.NICIP, 0);
+		}
+		
+		return isaLocal;
+	}
 }

--- a/src/main/java/org/littleshoot/proxy/DnsSecServerResolver.java
+++ b/src/main/java/org/littleshoot/proxy/DnsSecServerResolver.java
@@ -1,6 +1,7 @@
 package org.littleshoot.proxy;
 
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 
 import org.littleshoot.dnssec4j.VerifiedAddressFactory;
@@ -11,4 +12,9 @@ public class DnsSecServerResolver implements HostResolver {
             throws UnknownHostException {
         return VerifiedAddressFactory.newInetSocketAddress(host, port, true);
     }
+    
+    @Override
+	public InetSocketAddress resolveLocalAddr() throws SocketException {
+		throw new RuntimeException("Not implemented method");
+	}
 }

--- a/src/main/java/org/littleshoot/proxy/HostResolver.java
+++ b/src/main/java/org/littleshoot/proxy/HostResolver.java
@@ -1,6 +1,7 @@
 package org.littleshoot.proxy;
 
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 
 /**
@@ -9,4 +10,7 @@ import java.net.UnknownHostException;
 public interface HostResolver {
     public InetSocketAddress resolve(String host, int port)
             throws UnknownHostException;
+    
+    public InetSocketAddress resolveLocalAddr()
+            throws SocketException;
 }

--- a/src/main/java/org/littleshoot/proxy/Launcher.java
+++ b/src/main/java/org/littleshoot/proxy/Launcher.java
@@ -11,8 +11,8 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.xml.DOMConfigurator;
+import org.littleshoot.proxy.common.Constants;
 import org.littleshoot.proxy.extras.SelfSignedMitmManager;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.littleshoot.proxy.impl.ProxyUtils;
@@ -29,6 +29,8 @@ public class Launcher {
     private static final String OPTION_DNSSEC = "dnssec";
 
     private static final String OPTION_PORT = "port";
+    
+    private static final String OPTION_NIC = "nic";
 
     private static final String OPTION_HELP = "help";
     
@@ -47,6 +49,7 @@ public class Launcher {
         options.addOption(null, OPTION_DNSSEC, true,
                 "Request and verify DNSSEC signatures.");
         options.addOption(null, OPTION_PORT, true, "Run on the specified port.");
+        options.addOption(null, OPTION_NIC, true, "Run on a specified Nic");
         options.addOption(null, OPTION_HELP, false,
                 "Display command line help.");
         options.addOption(null, OPTION_MITM, false, "Run as man in the middle.");
@@ -88,6 +91,11 @@ public class Launcher {
                 .bootstrapFromFile("./littleproxy.properties")
                 .withPort(port)
                 .withAllowLocalOnly(false);
+        
+        if (cmd.hasOption(OPTION_NIC)) {
+        	final String val = cmd.getOptionValue(OPTION_NIC);
+        	Constants.NICIP = val;
+        }
         
         if (cmd.hasOption(OPTION_MITM)) {
             LOG.info("Running as Man in the Middle");

--- a/src/main/java/org/littleshoot/proxy/common/Constants.java
+++ b/src/main/java/org/littleshoot/proxy/common/Constants.java
@@ -1,0 +1,7 @@
+package org.littleshoot.proxy.common;
+
+public class Constants {
+
+	public static String NICIP = null;
+
+}


### PR DESCRIPTION
Added "-nic Default_Gateway" optional flag to specify gateway.

How to use in windows. Check "ipconfig" and see which all network interfaces are open. Use "ping -S IP hostname" to check its validity.
If you pass its gateway in '-nic' flag then source IPs would be different. Check it by accessing "http://whatismyipaddress.com/" (You may create proxy, set it in browser and check).

Known issues:
     I have seen some performance issues and sometimes proxy to server connection breaks. Apart from that some dongle/USB connection driver softwares set default gateway to "0.0.0.0" or similar. If this is the case then this gateway will be used for all purpose(I didnt use such connections). Task is to find a combination (Like LAN, WiFi, 2 or 3 Mobile connections through USB) that works. For me I got upto 5 different IPs (LAN, WiFi, 3 USB Connections).
