### PR TITLE
make ProxyToServerConnection accessible for filters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.14.Final</version>
+      <version>4.0.6.Final</version>
       <scope>compile</scope>
     </dependency>
     

--- a/src/main/java/org/littleshoot/proxy/HttpFilters.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFilters.java
@@ -6,6 +6,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 
+import org.littleshoot.proxy.impl.ProxyToServerConnection;
 import org.littleshoot.proxy.impl.ProxyUtils;
 
 /**
@@ -72,17 +73,19 @@ public interface HttpFilters {
      * Filters responses on their way from the server to the proxy.
      * 
      * @param httpObject
+     * @param con connection to the server
      * @return the modified (or unmodified) HttpObject. Returning null will
      *         force a disconnect.
      */
-    HttpObject responsePre(HttpObject httpObject);
+    HttpObject responsePre(HttpObject httpObject, ProxyToServerConnection con);
 
     /**
      * Filters responses on their way from the proxy to the client.
      * 
      * @param httpObject
+     * @param con connection to the server
      * @return the modified (or unmodified) HttpObject. Returning null will
      *         force a disconnect.
      */
-    HttpObject responsePost(HttpObject httpObject);
+    HttpObject responsePost(HttpObject httpObject, ProxyToServerConnection con);
 }

--- a/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
@@ -4,6 +4,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import org.littleshoot.proxy.impl.ProxyToServerConnection;
 
 /**
  * Convenience base class for implementations of {@link HttpFilters}.
@@ -33,12 +34,12 @@ public class HttpFiltersAdapter implements HttpFilters {
     }
 
     @Override
-    public HttpObject responsePre(HttpObject httpObject) {
+    public HttpObject responsePre(HttpObject httpObject, ProxyToServerConnection con) {
         return httpObject;
     }
 
     @Override
-    public HttpObject responsePost(HttpObject httpObject) {
+    public HttpObject responsePost(HttpObject httpObject, ProxyToServerConnection con) {
         return httpObject;
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -311,7 +311,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     void respond(ProxyToServerConnection serverConnection, HttpFilters filters,
             HttpRequest currentHttpRequest, HttpResponse currentHttpResponse,
             HttpObject httpObject) {
-        httpObject = filters.responsePre(httpObject);
+        httpObject = filters.responsePre(httpObject, serverConnection);
         if (httpObject == null) {
             forceDisconnect(serverConnection);
             return;
@@ -323,7 +323,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             modifyResponseHeadersToReflectProxying(httpResponse);
         }
 
-        httpObject = filters.responsePost(httpObject);
+        httpObject = filters.responsePost(httpObject, serverConnection);
         if (httpObject == null) {
             forceDisconnect(serverConnection);
             return;

--- a/src/test/java/org/littleshoot/proxy/MitmProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmProxyTest.java
@@ -13,6 +13,7 @@ import java.util.Queue;
 import java.util.Set;
 
 import org.littleshoot.proxy.extras.SelfSignedMitmManager;
+import org.littleshoot.proxy.impl.ProxyToServerConnection;
 
 /**
  * Tests just a single basic proxy running as a man in the middle.
@@ -64,7 +65,7 @@ public class MitmProxyTest extends BaseProxyTest {
                             }
 
                             @Override
-                            public HttpObject responsePre(HttpObject httpObject) {
+                            public HttpObject responsePre(HttpObject httpObject, ProxyToServerConnection con) {
                                 if (httpObject instanceof HttpResponse) {
                                     responsePreOriginalRequestMethodsSeen
                                             .add(originalRequest.getMethod());
@@ -77,7 +78,7 @@ public class MitmProxyTest extends BaseProxyTest {
                             }
 
                             @Override
-                            public HttpObject responsePost(HttpObject httpObject) {
+                            public HttpObject responsePost(HttpObject httpObject, ProxyToServerConnection con) {
                                 if (httpObject instanceof HttpResponse) {
                                     responsePostOriginalRequestMethodsSeen
                                             .add(originalRequest.getMethod());


### PR DESCRIPTION
Hi there, 
I face the problem that I need to validate the body of a response together with the ChainedProxy used for the request. As far as I can see the only way to access the body is to use a HttpFilter (and a response buffer limit) and the only way to access the used ChainedProxy is through an ActivityTracker, but there seems to be no way to access both at the same time. 

It is quite easy to hand down the ProxyToServerConnection to the HttpFilter, but it breaks the API. Is this something you would consider merging? Or is there a better way to access ChainedProxy?

Cheers, Lars 
