### PR TITLE
Allow port zero

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -157,7 +157,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
      *            our ServerGroup for shared thread pools and such
      * @param transportProtocol
      *            The protocol to use for data transport
-     * @param boundAddress
+     * @param requestedAddress
      *            The address on which this server will listen
      * @param sslEngineSource
      *            (optional) if specified, this Proxy will encrypt inbound
@@ -192,7 +192,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
      */
     private DefaultHttpProxyServer(ServerGroup serverGroup,
             TransportProtocol transportProtocol,
-            InetSocketAddress boundAddress,
+            InetSocketAddress requestedAddress,
             SslEngineSource sslEngineSource,
             boolean authenticateSslClients,
             ProxyAuthenticator proxyAuthenticator,
@@ -206,7 +206,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             HostResolver serverResolver) {
         this.serverGroup = serverGroup;
         this.transportProtocol = transportProtocol;
-        this.requestedAddress = boundAddress;
+        this.requestedAddress = requestedAddress;
         this.sslEngineSource = sslEngineSource;
         this.authenticateSslClients = authenticateSslClients;
         this.proxyAuthenticator = proxyAuthenticator;


### PR DESCRIPTION
Java allows specifying port 0 in order to have the JVM choose an open port for you [(InetSocketAddress javadoc)](https://docs.oracle.com/javase/7/docs/api/java/net/InetSocketAddress.html#InetSocketAddress%28java.net.InetAddress,%20int%29). Currently LittleProxy doesn't expose any mechanism (that I'm aware of) to retrieve the actual port the server is bound to after the proxy has been created. 

This PR tracks the "requestedPort" and "boundPort" separately, and exposes the second through the existing getListenAddress() method.
