### PR TITLE
Returning unresolved InetSocketAddress from resolution filter method

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -709,6 +709,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                     .proxyToServerResolutionStarted(serverHostAndPort);
             if (this.remoteAddress == null) {
                 this.remoteAddress = addressFor(serverHostAndPort, proxyServer);
+            } else if (this.remoteAddress.isUnresolved()) {
+                // filter returned an unresolved address, so resolve it using the proxy server's resolver
+                this.remoteAddress = proxyServer.getServerResolver().resolve(this.remoteAddress.getHostName(),
+                        this.remoteAddress.getPort());
             }
             this.currentFilters.proxyToServerResolutionSucceeded(
                     serverHostAndPort, this.remoteAddress);


### PR DESCRIPTION
I have a use case where I would like a filter to be able to modify a request hostname/port, but still use the proxy's default host name resolver (i.e. not resolve the address in the filter). I've added a check to ProxyToServerConnection.setupConnectionParameters() so that if the filter does return an unresolved address, it will attempt to resolve it using the usual proxy resolver.