### PR TITLE
crash fix for logs with no parameters

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnectionLogger.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnectionLogger.java
@@ -128,8 +128,13 @@ class ProxyConnectionLogger {
             final Object[] paramsWithThrowable;
 
             if (t != null) {
-                paramsWithThrowable = Arrays.copyOf(params,  params.length + 1);
-                paramsWithThrowable[params.length] = t;
+                if (params == null) {
+                    paramsWithThrowable = new Object[1];
+                    paramsWithThrowable[0] = t;
+                } else {
+                    paramsWithThrowable = Arrays.copyOf(params, params.length + 1);
+                    paramsWithThrowable[params.length] = t;
+                }
             }
             else {
                 paramsWithThrowable = params;


### PR DESCRIPTION
Logs don't always have a parameter. Like in `LocationAwareLogggerDispatch` the null `value` must be checked.
