### PR TITLE
Bind the Proxy to a specific network interface

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -298,7 +298,7 @@ public interface HttpProxyServerBootstrap {
      *
      * @param inetSocketAddress to be used for outgoing communication
      */
-    HttpProxyServerBootstrap useNetworkInterface(InetSocketAddress inetSocketAddress);
+    HttpProxyServerBootstrap withNetworkInterface(InetSocketAddress inetSocketAddress);
 
     /**
      * <p>
@@ -308,4 +308,5 @@ public interface HttpProxyServerBootstrap {
      * @return the newly built and started server
      */
     HttpProxyServer start();
+
 }

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -294,12 +294,18 @@ public interface HttpProxyServerBootstrap {
     HttpProxyServerBootstrap withThrottling(long readThrottleBytesPerSecond, long writeThrottleBytesPerSecond);
 
     /**
+     * All outgoing-communication of the proxy-instance is goin' to be routed via the given network-interface
+     *
+     * @param inetSocketAddress to be used for outgoing communication
+     */
+    HttpProxyServerBootstrap useNetworkInterface(InetSocketAddress inetSocketAddress);
+
+    /**
      * <p>
      * Build and starts the server.
      * </p>
-     * 
+     *
      * @return the newly built and started server
      */
     HttpProxyServer start();
-
 }

--- a/src/main/java/org/littleshoot/proxy/Launcher.java
+++ b/src/main/java/org/littleshoot/proxy/Launcher.java
@@ -1,8 +1,5 @@
 package org.littleshoot.proxy;
 
-import java.io.File;
-import java.util.Arrays;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -11,13 +8,16 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.xml.DOMConfigurator;
 import org.littleshoot.proxy.extras.SelfSignedMitmManager;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.littleshoot.proxy.impl.ProxyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
 
 /**
  * Launches a new HTTP proxy.
@@ -31,8 +31,10 @@ public class Launcher {
     private static final String OPTION_PORT = "port";
 
     private static final String OPTION_HELP = "help";
-    
+
     private static final String OPTION_MITM = "mitm";
+
+    private static final String OPTION_NIC = "nic";
 
     /**
      * Starts the proxy from the command line.
@@ -47,6 +49,7 @@ public class Launcher {
         options.addOption(null, OPTION_DNSSEC, true,
                 "Request and verify DNSSEC signatures.");
         options.addOption(null, OPTION_PORT, true, "Run on the specified port.");
+        options.addOption(null, OPTION_NIC, true, "Run on a specified Nic");
         options.addOption(null, OPTION_HELP, false,
                 "Display command line help.");
         options.addOption(null, OPTION_MITM, false, "Run as man in the middle.");
@@ -83,12 +86,18 @@ public class Launcher {
             port = defaultPort;
         }
 
+
         System.out.println("About to start server on port: " + port);
         HttpProxyServerBootstrap bootstrap = DefaultHttpProxyServer
                 .bootstrapFromFile("./littleproxy.properties")
                 .withPort(port)
                 .withAllowLocalOnly(false);
-        
+
+        if (cmd.hasOption(OPTION_NIC)) {
+            final String val = cmd.getOptionValue(OPTION_NIC);
+            bootstrap.useNetworkInterface(new InetSocketAddress(val, 0));
+        }
+
         if (cmd.hasOption(OPTION_MITM)) {
             LOG.info("Running as Man in the Middle");
             bootstrap.withManInTheMiddle(new SelfSignedMitmManager());
@@ -125,8 +134,7 @@ public class Launcher {
     }
 
     private static void pollLog4JConfigurationFileIfAvailable() {
-        File log4jConfigurationFile = new File(
-                "src/test/resources/log4j.xml");
+        File log4jConfigurationFile = new File("src/test/resources/log4j.xml");
         if (log4jConfigurationFile.exists()) {
             DOMConfigurator.configureAndWatch(
                     log4jConfigurationFile.getAbsolutePath(), 15);

--- a/src/main/java/org/littleshoot/proxy/Launcher.java
+++ b/src/main/java/org/littleshoot/proxy/Launcher.java
@@ -95,7 +95,7 @@ public class Launcher {
 
         if (cmd.hasOption(OPTION_NIC)) {
             final String val = cmd.getOptionValue(OPTION_NIC);
-            bootstrap.useNetworkInterface(new InetSocketAddress(val, 0));
+            bootstrap.withNetworkInterface(new InetSocketAddress(val, 0));
         }
 
         if (cmd.hasOption(OPTION_MITM)) {

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -1,8 +1,6 @@
 package org.littleshoot.proxy.impl;
 
 import static org.littleshoot.proxy.TransportProtocol.*;
-
-import com.google.common.base.Optional;
 import io.netty.bootstrap.ChannelFactory;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
@@ -722,7 +720,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         }
 
         @Override
-        public HttpProxyServerBootstrap useNetworkInterface(InetSocketAddress inetSocketAddress) {
+        public HttpProxyServerBootstrap withNetworkInterface(InetSocketAddress inetSocketAddress) {
             this.localAddress = inetSocketAddress;
             return this;
         }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -3,7 +3,6 @@ package org.littleshoot.proxy.impl;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ChannelFactory;
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.AdaptiveRecvByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelInitializer;
@@ -39,7 +38,10 @@ import org.slf4j.spi.LocationAwareLogger;
 import javax.net.ssl.SSLSession;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -57,7 +59,7 @@ import static org.littleshoot.proxy.impl.ConnectionState.HANDSHAKING;
  * ProxyConnections are reused fairly liberally, and can go from disconnected to
  * connected, back to disconnected and so on.
  * </p>
- * 
+ * <p/>
  * <p>
  * Connecting a {@link ProxyToServerConnection} can involve more than just
  * connecting the underlying {@link Channel}. In particular, the connection may
@@ -126,13 +128,13 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     private volatile GlobalTrafficShapingHandler trafficHandler;
 
     /**
-     * Minimum size of the adaptive recv buffer when throttling is enabled. 
+     * Minimum size of the adaptive recv buffer when throttling is enabled.
      */
     private static final int MINIMUM_RECV_BUFFER_SIZE_BYTES = 64;
-    
+
     /**
      * Create a new ProxyToServerConnection.
-     * 
+     *
      * @param proxyServer
      * @param clientConnection
      * @param serverHostAndPort
@@ -142,11 +144,11 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * @throws UnknownHostException
      */
     static ProxyToServerConnection create(DefaultHttpProxyServer proxyServer,
-            ClientToProxyConnection clientConnection,
-            String serverHostAndPort,
-            HttpFilters initialFilters,
-            HttpRequest initialHttpRequest,
-            GlobalTrafficShapingHandler globalTrafficShapingHandler)
+                                          ClientToProxyConnection clientConnection,
+                                          String serverHostAndPort,
+                                          HttpFilters initialFilters,
+                                          HttpRequest initialHttpRequest,
+                                          GlobalTrafficShapingHandler globalTrafficShapingHandler)
             throws UnknownHostException {
         Queue<ChainedProxy> chainedProxies = new ConcurrentLinkedQueue<ChainedProxy>();
         ChainedProxyManager chainedProxyManager = proxyServer
@@ -191,9 +193,11 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         setupConnectionParameters();
     }
 
-    /***************************************************************************
+    /**
+     * ************************************************************************
      * Reading
-     **************************************************************************/
+     * ************************************************************************
+     */
 
     @Override
     protected void read(Object msg) {
@@ -240,12 +244,12 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * doesn't know that any given response is to a HEAD request, so it needs to
      * be told that there's no content so that it doesn't hang waiting for it.
      * </p>
-     * 
+     * <p/>
      * <p>
      * See the documentation for {@link HttpResponseDecoder} for information
      * about why HEAD requests need special handling.
      * </p>
-     * 
+     * <p/>
      * <p>
      * Thanks to <a href="https://github.com/nataliakoval">nataliakoval</a> for
      * pointing out that with connections being reused as they are, this needs
@@ -255,7 +259,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     private class HeadAwareHttpResponseDecoder extends HttpResponseDecoder {
 
         public HeadAwareHttpResponseDecoder(int maxInitialLineLength,
-                int maxHeaderSize, int maxChunkSize) {
+                                            int maxHeaderSize, int maxChunkSize) {
             super(maxInitialLineLength, maxHeaderSize, maxChunkSize);
         }
 
@@ -269,7 +273,9 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             return HttpMethod.HEAD.equals(currentHttpRequest.getMethod()) ?
                     true : super.isContentAlwaysEmpty(httpMessage);
         }
-    };
+    }
+
+    ;
 
     /***************************************************************************
      * Writing
@@ -278,7 +284,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     /**
      * Like {@link #write(Object)} and also sets the current filters to the
      * given value.
-     * 
+     *
      * @param msg
      * @param filters
      */
@@ -319,7 +325,9 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             LOG.debug("Using existing connection to: {}", remoteAddress);
             doWrite(msg);
         }
-    };
+    }
+
+    ;
 
     @Override
     protected void writeHttp(HttpObject httpObject) {
@@ -334,9 +342,11 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         super.writeHttp(httpObject);
     }
 
-    /***************************************************************************
+    /**
+     * ************************************************************************
      * Lifecycle
-     **************************************************************************/
+     * ************************************************************************
+     */
 
     @Override
     protected void become(ConnectionState newState) {
@@ -422,9 +432,11 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         // connection, so there should not be any further action to take here.
     }
 
-    /***************************************************************************
+    /**
+     * ************************************************************************
      * State Management
-     **************************************************************************/
+     * ************************************************************************
+     */
     public TransportProtocol getTransportProtocol() {
         return transportProtocol;
     }
@@ -486,7 +498,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     /**
      * Keeps track of the current HttpResponse so that we can associate its
      * headers with future related chunks for this same transfer.
-     * 
+     *
      * @param response
      */
     private void rememberCurrentResponse(HttpResponse response) {
@@ -501,7 +513,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
     /**
      * Respond to the client with the given {@link HttpObject}.
-     * 
+     *
      * @param httpObject
      */
     private void respondWith(HttpObject httpObject) {
@@ -512,7 +524,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     /**
      * Connects to the server and then writes out the initial request (or
      * upgrades to an SSL tunnel, depending).
-     * 
+     *
      * @param initialRequest
      */
     private void connectAndWrite(final HttpRequest initialRequest) {
@@ -577,33 +589,36 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                     .getProxyToServerWorkerFor(transportProtocol));
 
             switch (transportProtocol) {
-            case TCP:
-                LOG.debug("Connecting to server with TCP");
-                cb.channelFactory(new ChannelFactory<Channel>() {
-                    @Override
-                    public Channel newChannel() {
-                        return new NioSocketChannel();
-                    }
-                });
-                break;
-            case UDT:
-                LOG.debug("Connecting to server with UDT");
-                cb.channelFactory(NioUdtProvider.BYTE_CONNECTOR)
-                        .option(ChannelOption.SO_REUSEADDR, true);
-                break;
-            default:
-                throw new UnknownTransportProtocolError(transportProtocol);
+                case TCP:
+                    LOG.debug("Connecting to server with TCP");
+                    cb.channelFactory(new ChannelFactory<Channel>() {
+                        @Override
+                        public Channel newChannel() {
+                            return new NioSocketChannel();
+                        }
+                    });
+                    break;
+                case UDT:
+                    LOG.debug("Connecting to server with UDT");
+                    cb.channelFactory(NioUdtProvider.BYTE_CONNECTOR)
+                            .option(ChannelOption.SO_REUSEADDR, true);
+                    break;
+                default:
+                    throw new UnknownTransportProtocolError(transportProtocol);
             }
 
             cb.handler(new ChannelInitializer<Channel>() {
                 protected void initChannel(Channel ch) throws Exception {
                     initChannelPipeline(ch.pipeline(), initialRequest);
-                };
+                }
+
+                ;
             });
             cb.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
                     proxyServer.getConnectTimeout());
 
             if (localAddress != null) {
+                cb.bind(localAddress);
                 return cb.connect(remoteAddress, localAddress);
             } else {
                 return cb.connect(remoteAddress);
@@ -650,7 +665,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * <p>
      * Encrypts the client channel based on our server {@link SSLSession}.
      * </p>
-     * 
+     * <p/>
      * <p>
      * This does not wait for the handshake to finish so that we can go on and
      * respond to the CONNECT request.
@@ -691,14 +706,13 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * <p>
      * Called to let us know that connection failed.
      * </p>
-     * 
+     * <p/>
      * <p>
      * Try connecting to a new address, using a new set of connection
      * parameters.
      * </p>
-     * 
-     * @param cause
-     *            the reason that our attempt to connect failed (can be null)
+     *
+     * @param cause the reason that our attempt to connect failed (can be null)
      * @return true if we are trying to fall back to another connection
      */
     protected boolean connectionFailed(Throwable cause)
@@ -728,7 +742,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     /**
      * Set up our connection parameters based on server address and chained
      * proxies.
-     * 
+     *
      * @throws UnknownHostException
      */
     private void setupConnectionParameters() throws UnknownHostException {
@@ -753,18 +767,18 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             this.currentFilters.proxyToServerResolutionSucceeded(
                     serverHostAndPort, this.remoteAddress);
 
-            this.localAddress = null;
+            this.localAddress = proxyServer.getLocalAddress();
         }
     }
 
     /**
      * Initialize our {@link ChannelPipeline}.
-     * 
+     *
      * @param pipeline
      * @param httpRequest
      */
     private void initChannelPipeline(ChannelPipeline pipeline,
-            HttpRequest httpRequest) {
+                                     HttpRequest httpRequest) {
 
         if (trafficHandler != null) {
             pipeline.addLast("global-traffic-shaping", trafficHandler);
@@ -804,10 +818,9 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
      * Do all the stuff that needs to be done after our {@link ConnectionFlow}
      * has succeeded.
      * </p>
-     * 
-     * @param shouldForwardInitialRequest
-     *            whether or not we should forward the initial HttpRequest to
-     *            the server after the connection has been established.
+     *
+     * @param shouldForwardInitialRequest whether or not we should forward the initial HttpRequest to
+     *                                    the server after the connection has been established.
      */
     void connectionSucceeded(boolean shouldForwardInitialRequest) {
         become(AWAITING_INITIAL);
@@ -832,16 +845,14 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
     /**
      * Build an {@link InetSocketAddress} for the given hostAndPort.
-     * 
+     *
      * @param hostAndPort
-     * @param proxyServer
-     *            the current {@link DefaultHttpProxyServer}
+     * @param proxyServer the current {@link DefaultHttpProxyServer}
      * @return
-     * @throws UnknownHostException
-     *             if hostAndPort could not be resolved
+     * @throws UnknownHostException if hostAndPort could not be resolved
      */
     private static InetSocketAddress addressFor(String hostAndPort,
-            DefaultHttpProxyServer proxyServer)
+                                                DefaultHttpProxyServer proxyServer)
             throws UnknownHostException {
         String host;
         int port;
@@ -858,12 +869,14 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         return proxyServer.getServerResolver().resolve(host, port);
     }
 
-    /***************************************************************************
+    /**
+     * ************************************************************************
      * Activity Tracking/Statistics
-     * 
+     * <p/>
      * We track statistics on bytes, requests and responses by adding handlers
      * at the appropriate parts of the pipeline (see initChannelPipeline()).
-     **************************************************************************/
+     * ************************************************************************
+     */
     private final BytesReadMonitor bytesReadMonitor = new BytesReadMonitor() {
         @Override
         protected void bytesRead(int numberOfBytes) {


### PR DESCRIPTION
I tumbled upon the discussion about binding the proxy to a specific network interface https://github.com/adamfisk/LittleProxy/issues/135 since I was looking for exactly the same feature (have a server with a bunch of IPs and I'd like to control over what interface a program communicates).
During that discussion jibijose came up with a sulotion https://github.com/jibijose/LittleProxy/commit/aa180eb718b6517481a399ec080fc11a62966048 but as it seems with no outcome. So I took this approach, tweaked it just a little since the original solution already worked for me and created this pull request. 