### PR TITLE
Required maven version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>2.28.0</version>
+      <version>2.44.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
   </dependencies>
 
   <prerequisites>
-    <maven>2.2.1</maven>
+    <maven>3.0</maven>
   </prerequisites>
 
   <build>
@@ -365,7 +365,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.0</version>
+        <version>2.3</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,21 @@
     <dependency>
       <groupId>org.littleshoot</groupId>
       <artifactId>dnssec4j</artifactId>
-      <version>0.1</version>
+      <version>0.1.6</version>
+      <optional>true</optional>
+      <exclusions>
+          <exclusion>
+              <groupId>org.littleshoot</groupId>
+              <artifactId>dnsjava</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>dnsjava</groupId>
+      <artifactId>dnsjava</artifactId>
+      <version>2.1.7</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This is a minor pom correctness update: the pom declared a minimum version of maven 2.2.1, but the maven-shade-plugin requires a minimum version of 3.0, so attempting to use maven 2.2.1 actually fails. I've updated the required maven version accordingly.

I also updated to maven-shade-plugin 2.3, which contains a few performance improvements and bugfixes.