### PR TITLE
Allow non-graceful shutdown

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServer.java
@@ -29,9 +29,14 @@ public interface HttpProxyServer {
     HttpProxyServerBootstrap clone();
 
     /**
-     * Stops the server and all related clones.
+     * Stops the server and all related clones. Waits for traffic to stop before shutting down.
      */
     void stop();
+
+    /**
+     * Stops the server and all related clones immediately, without waiting for traffic to stop.
+     */
+    void abort();
 
     /**
      * Return the address on which this proxy is listening.

--- a/src/test/java/org/littleshoot/proxy/StopProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/StopProxyTest.java
@@ -1,0 +1,24 @@
+package org.littleshoot.proxy;
+
+import org.junit.Test;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+public class StopProxyTest {
+    @Test
+    public void testStop() {
+        HttpProxyServer proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
+
+        proxyServer.stop();
+    }
+
+    @Test
+    public void testAbort() {
+        HttpProxyServer proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
+
+        proxyServer.abort();
+    }
+}


### PR DESCRIPTION
I noticed while running tests with LittleProxy that they were taking about three times as long as the non-LittleProxy backend. Each test spins up and shuts down a LittleProxy instance, and the shutdown part of the test was taking a few seconds, which adds up quickly across 100+ tests.

My thought was to add an abort() option to the HttpProxyServer interface that would initiate a non-graceful shutdown, killing off connections as quickly as possible and not waiting for traffic to stop.

I put together this PR that implements the abort. However I'm not familiar enough with netty to know what side-effects this type of fast shutdown might have. Does anybody know if there may be leaks or other negative consequences from this?