### PR TITLE
Added Server's ChannelHandlerContext to filters

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpFilters.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFilters.java
@@ -1,5 +1,6 @@
 package org.littleshoot.proxy;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
 import org.littleshoot.proxy.impl.ProxyUtils;
 
@@ -175,7 +176,9 @@ public interface HttpFilters {
 
     /**
      * Informs filter that proxy to server connection has succeeded.
+     *
+     * @param serverCtx the {@link io.netty.channel.ChannelHandlerContext} used to connect to the server
      */
-    void proxyToServerConnectionSucceeded();
+    void proxyToServerConnectionSucceeded(ChannelHandlerContext serverCtx);
 
 }

--- a/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
@@ -13,7 +13,6 @@ import java.net.InetSocketAddress;
 public class HttpFiltersAdapter implements HttpFilters {
     protected final HttpRequest originalRequest;
     protected final ChannelHandlerContext ctx;
-    protected volatile ChannelHandlerContext serverCtx;
 
     public HttpFiltersAdapter(HttpRequest originalRequest,
             ChannelHandlerContext ctx) {
@@ -90,6 +89,5 @@ public class HttpFiltersAdapter implements HttpFilters {
 
     @Override
     public void proxyToServerConnectionSucceeded(ChannelHandlerContext serverCtx) {
-        this.serverCtx = serverCtx;
     }
 }

--- a/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
@@ -13,6 +13,7 @@ import java.net.InetSocketAddress;
 public class HttpFiltersAdapter implements HttpFilters {
     protected final HttpRequest originalRequest;
     protected final ChannelHandlerContext ctx;
+    protected volatile ChannelHandlerContext serverCtx;
 
     public HttpFiltersAdapter(HttpRequest originalRequest,
             ChannelHandlerContext ctx) {
@@ -88,6 +89,7 @@ public class HttpFiltersAdapter implements HttpFilters {
     }
 
     @Override
-    public void proxyToServerConnectionSucceeded() {
+    public void proxyToServerConnectionSucceeded(ChannelHandlerContext serverCtx) {
+        this.serverCtx = serverCtx;
     }
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -3,7 +3,6 @@ package org.littleshoot.proxy.impl;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ChannelFactory;
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.AdaptiveRecvByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelInitializer;
@@ -347,13 +346,13 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             if (newState == HANDSHAKING) {
                 currentFilters.proxyToServerConnectionSSLHandshakeStarted();
             } else if (newState == AWAITING_INITIAL) {
-                currentFilters.proxyToServerConnectionSucceeded();
+                currentFilters.proxyToServerConnectionSucceeded(ctx);
             } else if (newState == DISCONNECTED) {
                 currentFilters.proxyToServerConnectionFailed();
             }
         } else if (getCurrentState() == HANDSHAKING
                 && newState == AWAITING_INITIAL) {
-            currentFilters.proxyToServerConnectionSucceeded();
+            currentFilters.proxyToServerConnectionSucceeded(ctx);
         } else if (getCurrentState() == AWAITING_CHUNK
                 && newState != AWAITING_CHUNK) {
             currentFilters.serverToProxyResponseReceived();

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -779,7 +779,7 @@ public class HttpFilterTest {
         }
 
         @Override
-        public void proxyToServerConnectionSucceeded() {
+        public void proxyToServerConnectionSucceeded(ChannelHandlerContext serverCtx) {
             proxyToServerConnectionSucceeded.set(true);
         }
 


### PR DESCRIPTION
Currently in the HttpFilters the ClientToProxyConnection's ChannelHandlerContext is available to the filters via the HttpFiltersSource's `filterRequest(HttpRequest originalRequest, ChannelHandlerContext ctx)` method. The HttpFiltersAdapter class makes that context available via the protected member variable ctx. However, the server's ChannelHandlerContext is not available to the filters, even though it is "known" at the time the filters are called.

This PR exposes the ProxyToServerConnection's ChannelHandlerContext in the proxyToServerConnectionSucceeded() filter method, and in the HttpFiltersAdapter default implementation it captures the serverCtx.

The use case I'm trying to solve here is to capture the IP address (and possibly the hostname) of the remote server that we are actually connected to. The HttpRequest isn't enough to infer this information, since it (generally) contains a hostname, rather than a resolved IP address. The filters *could* re-resolve the hostname to an IP address, but that takes additional time, and may not even resolve the same IP address that the server is actually connected to. Having direct access to the server's ChannelHandlerContext is the most straightforward way to capture server connection information in a filter. It is also "symmetric" in that the ClientToProxy ChannelHandlerContext is already available to the filters.

I'm interested in getting people's thoughts on this from an architecture standpoint -- is this the right way to expose server connection information to filters? If not, where would you recommend I put it?