### PR TITLE
HTTP CONNECT requests don't pass through 407, making it impossible for client to authenticate with downstream proxy #126 

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -500,13 +500,23 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         serverConnection.getRemoteAddress(),
                         lastStateBeforeFailure,
                         cause);
-                connectionFailedUnrecoverably(initialRequest);
+                connectionFailedUnrecoverablyWithExactResponse(initialRequest);
                 return false;
             }
         } catch (UnknownHostException uhe) {
             connectionFailedUnrecoverably(initialRequest);
             return false;
         }
+    }
+
+    private void connectionFailedUnrecoverablyWithExactResponse(HttpRequest initialRequest) {
+        writeExactResponse(initialRequest);
+        become(DISCONNECT_REQUESTED);
+    }
+
+    private void writeExactResponse(HttpRequest request) {
+        write(currentServerConnection.getCurrentHttpResponse());
+        disconnect();
     }
 
     private void connectionFailedUnrecoverably(HttpRequest initialRequest) {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -454,6 +454,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         return initialRequest;
     }
 
+    public HttpResponse getCurrentHttpResponse( ){
+        return currentHttpResponse;
+    }
+
     @Override
     protected HttpFilters getHttpFiltersFromProxyServer(HttpRequest httpRequest) {
         return currentFilters;
@@ -633,6 +637,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             boolean connectOk = false;
             if (msg instanceof HttpResponse) {
                 HttpResponse httpResponse = (HttpResponse) msg;
+                currentHttpResponse = httpResponse;
                 int statusCode = httpResponse.getStatus().code();
                 if (statusCode >= 200 && statusCode <= 299) {
                     connectOk = true;


### PR DESCRIPTION
Fix for #89 and #126. CONNECT response in case of non 2xx status sends back the exact response.