### PR TITLE
Revert PR #187

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -500,23 +500,13 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         serverConnection.getRemoteAddress(),
                         lastStateBeforeFailure,
                         cause);
-                connectionFailedUnrecoverablyWithExactResponse(initialRequest);
+                connectionFailedUnrecoverably(initialRequest);
                 return false;
             }
         } catch (UnknownHostException uhe) {
             connectionFailedUnrecoverably(initialRequest);
             return false;
         }
-    }
-
-    private void connectionFailedUnrecoverablyWithExactResponse(HttpRequest initialRequest) {
-        writeExactResponse(initialRequest);
-        become(DISCONNECT_REQUESTED);
-    }
-
-    private void writeExactResponse(HttpRequest request) {
-        write(currentServerConnection.getCurrentHttpResponse());
-        disconnect();
     }
 
     private void connectionFailedUnrecoverably(HttpRequest initialRequest) {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -454,10 +454,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         return initialRequest;
     }
 
-    public HttpResponse getCurrentHttpResponse( ){
-        return currentHttpResponse;
-    }
-
     @Override
     protected HttpFilters getHttpFiltersFromProxyServer(HttpRequest httpRequest) {
         return currentFilters;
@@ -638,7 +634,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             boolean connectOk = false;
             if (msg instanceof HttpResponse) {
                 HttpResponse httpResponse = (HttpResponse) msg;
-                currentHttpResponse = httpResponse;
                 int statusCode = httpResponse.getStatus().code();
                 if (statusCode >= 200 && statusCode <= 299) {
                     connectOk = true;


### PR DESCRIPTION
Reverts adamfisk/LittleProxy#187. It is causing a serious defect (stack trace below) in many unit tests.

```
1393   2015-03-14 19:14:53,729 WARN  [Downstream-ProxyToServerWorker-0] concurrent.DefaultPromise (?:?).?() - An exception was thrown by org.littleshoot.proxy.impl.ConnectionFlow$3.operationComplete()
java.lang.NullPointerException: msg
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:697)
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:741)
	at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:895)
	at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:240)
	at org.littleshoot.proxy.impl.ProxyConnection.writeToChannel(ProxyConnection.java:258)
	at org.littleshoot.proxy.impl.ProxyConnection.writeRaw(ProxyConnection.java:254)
	at org.littleshoot.proxy.impl.ProxyConnection.doWrite(ProxyConnection.java:226)
	at org.littleshoot.proxy.impl.ProxyConnection.write(ProxyConnection.java:216)
	at org.littleshoot.proxy.impl.ClientToProxyConnection.writeExactResponse(ClientToProxyConnection.java:518)
	at org.littleshoot.proxy.impl.ClientToProxyConnection.connectionFailedUnrecoverablyWithExactResponse(ClientToProxyConnection.java:513)
	at org.littleshoot.proxy.impl.ClientToProxyConnection.serverConnectionFailed(ClientToProxyConnection.java:503)
	at org.littleshoot.proxy.impl.ConnectionFlow$3.operationComplete(ConnectionFlow.java:188)
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:680)
	at io.netty.util.concurrent.DefaultPromise.notifyLateListener(DefaultPromise.java:621)
	at io.netty.util.concurrent.DefaultPromise.addListener(DefaultPromise.java:138)
	at io.netty.channel.DefaultChannelPromise.addListener(DefaultChannelPromise.java:93)
	at io.netty.channel.DefaultChannelPromise.addListener(DefaultChannelPromise.java:28)
	at org.littleshoot.proxy.impl.ConnectionFlow.fail(ConnectionFlow.java:182)
	at org.littleshoot.proxy.impl.ConnectionFlow$2.operationComplete(ConnectionFlow.java:153)
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:680)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:603)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:563)
	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:424)
	at io.netty.handler.ssl.SslHandler.notifyHandshakeFailure(SslHandler.java:1122)
	at io.netty.handler.ssl.SslHandler.setHandshakeFailure(SslHandler.java:1117)
	at io.netty.handler.ssl.SslHandler.channelInactive(SslHandler.java:605)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:233)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:219)
	at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:769)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$5.run(AbstractChannel.java:567)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:380)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:357)
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
	at java.lang.Thread.run(Thread.java:745)
```