### PR TITLE
Unit test fixes and cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,22 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.0</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.0.5-beta</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-netty</artifactId>
+      <version>3.9.1</version>
+      <scope>test</scope>
+      <exclusions>
+          <exclusion>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-classic</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/test/java/org/littleshoot/proxy/BaseChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BaseChainedProxyTest.java
@@ -19,11 +19,6 @@ import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
  * by the downstream proxy was received by the upstream proxy.
  */
 public abstract class BaseChainedProxyTest extends BaseProxyTest {
-    protected static final AtomicInteger UPSTREAM_PROXY_SERVER_PORT_SEQ = new AtomicInteger(
-            59000);
-
-    private int upstreamProxyPort;
-
     private final AtomicLong REQUESTS_SENT_BY_DOWNSTREAM = new AtomicLong(
             0l);
     private final AtomicLong REQUESTS_RECEIVED_BY_UPSTREAM = new AtomicLong(
@@ -52,17 +47,13 @@ public abstract class BaseChainedProxyTest extends BaseProxyTest {
 
     @Override
     protected void setUp() {
-        // Set up ports from sequence
-        upstreamProxyPort = UPSTREAM_PROXY_SERVER_PORT_SEQ
-                .getAndIncrement();
-
         REQUESTS_SENT_BY_DOWNSTREAM.set(0);
         REQUESTS_RECEIVED_BY_UPSTREAM.set(0);
         TRANSPORTS_USED.clear();
         this.upstreamProxy = upstreamProxy().start();
         this.proxyServer = bootstrapProxy()
                 .withName("Downstream")
-                .withPort(proxyServerPort)
+                .withPort(0)
                 .withChainProxyManager(chainedProxyManager())
                 .plusActivityTracker(DOWNSTREAM_TRACKER).start();
     }
@@ -70,7 +61,7 @@ public abstract class BaseChainedProxyTest extends BaseProxyTest {
     protected HttpProxyServerBootstrap upstreamProxy() {
         return DefaultHttpProxyServer.bootstrap()
                 .withName("Upstream")
-                .withPort(upstreamProxyPort)
+                .withPort(0)
                 .plusActivityTracker(UPSTREAM_TRACKER);
     }
     
@@ -141,7 +132,7 @@ public abstract class BaseChainedProxyTest extends BaseProxyTest {
             try {
                 return new InetSocketAddress(InetAddress
                         .getByName("127.0.0.1"),
-                        upstreamProxyPort);
+                        upstreamProxy.getListenAddress().getPort());
             } catch (UnknownHostException uhe) {
                 throw new RuntimeException(
                         "Unable to resolve 127.0.0.1?!");

--- a/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackTest.java
+++ b/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackTest.java
@@ -25,7 +25,7 @@ public class ChainedProxyWithFallbackTest extends BaseProxyTest {
         unableToConnect.set(false);
         this.proxyServer = bootstrapProxy()
                 .withName("Downstream")
-                .withPort(proxyServerPort)
+                .withPort(0)
                 .withChainProxyManager(new ChainedProxyManager() {
                     @Override
                     public void lookupChainedProxies(HttpRequest httpRequest,

--- a/src/test/java/org/littleshoot/proxy/EncryptedUDTChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/EncryptedUDTChainedProxyTest.java
@@ -2,16 +2,11 @@ package org.littleshoot.proxy;
 
 import static org.littleshoot.proxy.TransportProtocol.*;
 
-import java.net.InetSocketAddress;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.net.ssl.SSLEngine;
 
 import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
 
 public class EncryptedUDTChainedProxyTest extends BaseChainedProxyTest {
-    private static final AtomicInteger localPort = new AtomicInteger(61000);
-
     private final SslEngineSource sslEngineSource = new SelfSignedSslEngineSource(
             "chain_proxy_keystore_1.jks");
 
@@ -38,12 +33,6 @@ public class EncryptedUDTChainedProxyTest extends BaseChainedProxyTest {
             @Override
             public SSLEngine newSslEngine() {
                 return sslEngineSource.newSslEngine();
-            }
-
-            @Override
-            public InetSocketAddress getLocalAddress() {
-                return new InetSocketAddress("127.0.0.1",
-                        localPort.getAndIncrement());
             }
         };
     }

--- a/src/test/java/org/littleshoot/proxy/IdleTest.java
+++ b/src/test/java/org/littleshoot/proxy/IdleTest.java
@@ -11,27 +11,30 @@ import org.junit.Before;
 import org.junit.Test;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
+import static org.junit.Assume.assumeTrue;
+
 /**
  * Note - this test only works on UNIX systems because it checks file descriptor
  * counts.
  */
 public class IdleTest {
     private static final int NUMBER_OF_CONNECTIONS_TO_OPEN = 2000;
-    private static final int WEB_SERVER_PORT = 9091;
-    private static final int PROXY_PORT = 9091;
 
-    private int originalIdleTimeout;
     private Server webServer;
+    private int webServerPort = -1;
     private HttpProxyServer proxyServer;
 
     @Before
     public void setup() throws Exception {
-        webServer = new Server(WEB_SERVER_PORT);
+        assumeTrue("Skipping due to non-Unix OS", TestUtils.isUnixManagementCapable());
+
+        webServer = new Server(0);
         webServer.start();
+        webServerPort = TestUtils.findLocalHttpPort(webServer);
+
         proxyServer = DefaultHttpProxyServer.bootstrap()
-                .withPort(PROXY_PORT)
+                .withPort(0)
                 .start();
-        originalIdleTimeout = proxyServer.getIdleConnectionTimeout();
         proxyServer.setIdleConnectionTimeout(10);
 
     }
@@ -39,22 +42,25 @@ public class IdleTest {
     @After
     public void tearDown() throws Exception {
         try {
-            webServer.stop();
+            if (webServer != null) {
+                webServer.stop();
+            }
         } finally {
-            proxyServer.stop();
+            if (proxyServer != null) {
+                proxyServer.stop();
+            }
         }
-        proxyServer.setIdleConnectionTimeout(originalIdleTimeout);
     }
 
     @Test
-    public void test() throws Exception {
+    public void testFileDescriptorCount() throws Exception {
         System.out
                 .println("------------------ Memory Usage At Beginning ------------------");
         long initialFileDescriptors = TestUtils.getOpenFileDescriptorsAndPrintMemoryUsage();
         Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(
-                "127.0.0.1", PROXY_PORT));
+                "127.0.0.1", proxyServer.getListenAddress().getPort()));
         for (int i = 0; i < NUMBER_OF_CONNECTIONS_TO_OPEN; i++) {
-            new URL("http://localhost:" + WEB_SERVER_PORT)
+            new URL("http://localhost:" + webServerPort)
                     .openConnection(proxy).connect();
         }
 
@@ -77,7 +83,10 @@ public class IdleTest {
 
         double fdDeltaRatio = Math.abs(fdDeltaToClosed / fdDeltaToOpen);
         Assert.assertTrue(
-                "Number of file descriptors after close should be much closer to initial value than number of file descriptors while open",
+                "Number of file descriptors after close should be much closer to initial value than number of file descriptors while open (+/- 1%).\n"
+                        + "Initial file descriptors: " + initialFileDescriptors + "; file descriptors while connections open: " + fileDescriptorsWhileConnectionsOpen + "; "
+                        + "file descriptors after connections closed: " + fileDescriptorsAfterConnectionsClosed + "\n"
+                        + "Ratio of file descriptors after connections are closed to descriptors before connections were closed: " + fdDeltaRatio,
                 fdDeltaRatio < 0.01);
     }
 }

--- a/src/test/java/org/littleshoot/proxy/IdlingProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/IdlingProxyTest.java
@@ -11,7 +11,7 @@ public class IdlingProxyTest extends AbstractProxyTest {
     @Override
     protected void setUp() {
         this.proxyServer = bootstrapProxy()
-                .withPort(proxyServerPort)
+                .withPort(0)
                 .withIdleConnectionTimeout(1)
                 .start();
     }

--- a/src/test/java/org/littleshoot/proxy/MITMUsernamePasswordAuthenticatingProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MITMUsernamePasswordAuthenticatingProxyTest.java
@@ -12,7 +12,7 @@ public class MITMUsernamePasswordAuthenticatingProxyTest extends
     @Override
     protected void setUp() {
         this.proxyServer = bootstrapProxy()
-                .withPort(proxyServerPort)
+                .withPort(0)
                 .withProxyAuthenticator(this)
                 .withManInTheMiddle(new SelfSignedMitmManager())
                 .start();

--- a/src/test/java/org/littleshoot/proxy/MitmProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmProxyTest.java
@@ -25,7 +25,7 @@ public class MitmProxyTest extends BaseProxyTest {
     @Override
     protected void setUp() {
         this.proxyServer = bootstrapProxy()
-                .withPort(proxyServerPort)
+                .withPort(0)
                 // Include a ChainedProxyManager to make sure that MITM setting
                 // overrides this
                 .withChainProxyManager(new ChainedProxyManager() {

--- a/src/test/java/org/littleshoot/proxy/NoChainedProxiesTest.java
+++ b/src/test/java/org/littleshoot/proxy/NoChainedProxiesTest.java
@@ -13,7 +13,7 @@ public class NoChainedProxiesTest extends AbstractProxyTest {
     @Override
     protected void setUp() {
         this.proxyServer = bootstrapProxy()
-                .withPort(proxyServerPort)
+                .withPort(0)
                 .withChainProxyManager(new ChainedProxyManager() {
                     @Override
                     public void lookupChainedProxies(HttpRequest httpRequest,

--- a/src/test/java/org/littleshoot/proxy/SimpleProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/SimpleProxyTest.java
@@ -7,7 +7,7 @@ public class SimpleProxyTest extends BaseProxyTest {
     @Override
     protected void setUp() {
         this.proxyServer = bootstrapProxy()
-                .withPort(proxyServerPort)
+                .withPort(0)
                 .start();
     }
 }

--- a/src/test/java/org/littleshoot/proxy/TimeoutTest.java
+++ b/src/test/java/org/littleshoot/proxy/TimeoutTest.java
@@ -1,0 +1,107 @@
+package org.littleshoot.proxy;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.matchers.Times;
+import org.mockserver.model.Delay;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public class TimeoutTest {
+    private ClientAndServer mockServer;
+    private int mockServerPort;
+
+    private HttpProxyServer proxyServer;
+
+    @Before
+    public void setUp() {
+        // replace this with port 0 when MockServer supports it
+        mockServerPort = new Random().nextInt(55000) + 10000;
+        mockServer = new ClientAndServer(mockServerPort);
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            if (mockServer != null) {
+                mockServer.stop();
+            }
+        } finally {
+            if (proxyServer != null) {
+                proxyServer.stop();
+            }
+        }
+    }
+
+    @Test
+    public void testIdleConnectionTimeout() throws IOException {
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .withIdleConnectionTimeout(1)
+                .start();
+
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/idleconnection"),
+                Times.exactly(1))
+                .respond(response()
+                                .withStatusCode(200)
+                                .withDelay(new Delay(TimeUnit.SECONDS, 5))
+                );
+
+        DefaultHttpClient httpClient = new DefaultHttpClient();
+        final HttpHost proxy = new HttpHost("127.0.0.1", proxyServer.getListenAddress().getPort(), "http");
+        httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+
+        long start = System.nanoTime();
+        HttpGet get = new HttpGet("http://127.0.0.1:" + mockServerPort + "/idleconnection");
+        long stop = System.nanoTime();
+
+        HttpResponse response = httpClient.execute(get);
+        EntityUtils.consumeQuietly(response.getEntity());
+
+        assertEquals("Expected to receive an HTTP 504 (Gateway Timeout) response after proxy did not receive a response within 1 second", 504, response.getStatusLine().getStatusCode());
+        assertTrue("Expected idle connection timeout to happen after approximately 1 second. Total time was: " + TimeUnit.MILLISECONDS.convert(stop - start, TimeUnit.NANOSECONDS) + "ms",
+                TimeUnit.SECONDS.convert(stop - start, TimeUnit.NANOSECONDS) < 2);
+    }
+
+    @Test
+    public void testConnectionTimeout() throws IOException {
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .withConnectTimeout(1000)
+                .start();
+
+        DefaultHttpClient httpClient = new DefaultHttpClient();
+        final HttpHost proxy = new HttpHost("127.0.0.1", proxyServer.getListenAddress().getPort(), "http");
+        httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+
+        HttpGet get = new HttpGet("http://1.2.3.4:");
+
+        long start = System.nanoTime();
+        HttpResponse response = httpClient.execute(get);
+        long stop = System.nanoTime();
+
+        EntityUtils.consumeQuietly(response.getEntity());
+
+        assertEquals("Expected to receive an HTTP 502 (Bad Gateway) response after proxy could not connect within 1 second", 502, response.getStatusLine().getStatusCode());
+        assertTrue("Expected connection timeout to happen after approximately 1 second. Total time was: " + TimeUnit.MILLISECONDS.convert(stop - start, TimeUnit.NANOSECONDS) + "ms",
+                TimeUnit.SECONDS.convert(stop - start, TimeUnit.NANOSECONDS) < 2);
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/TimeoutTest.java
+++ b/src/test/java/org/littleshoot/proxy/TimeoutTest.java
@@ -92,7 +92,7 @@ public class TimeoutTest {
         final HttpHost proxy = new HttpHost("127.0.0.1", proxyServer.getListenAddress().getPort(), "http");
         httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
 
-        HttpGet get = new HttpGet("http://1.2.3.4:");
+        HttpGet get = new HttpGet("http://1.2.3.4:53540");
 
         long start = System.nanoTime();
         HttpResponse response = httpClient.execute(get);

--- a/src/test/java/org/littleshoot/proxy/UsernamePasswordAuthenticatingProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/UsernamePasswordAuthenticatingProxyTest.java
@@ -8,7 +8,7 @@ public class UsernamePasswordAuthenticatingProxyTest extends BaseProxyTest
     @Override
     protected void setUp() {
         this.proxyServer = bootstrapProxy()
-                .withPort(proxyServerPort)
+                .withPort(0)
                 .withProxyAuthenticator(this)
                 .start();
     }


### PR DESCRIPTION
This PR should fix most, if not all, unit test failures (all tests now pass for me). The changes are:
- Uses port 0 (JVM-assigned) for all proxy server and jetty web server instances, to avoid BindExceptions due to port collisions
- Fixes errors in IdleTest, and skips IdleTest on non-Unix OSes
- Uses [MockServer](http://www.mock-server.com/) to provide actual HTTP responses for a few key tests, including a new TimeoutTest. We can leverage this for future tests too.