### PR TITLE
Enabling JDK 6, 7, and 8 and caching in travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
+sudo: false
+
 language: java
+jdk:
+  - oraclejdk7
+  - oraclejdk8
+
+cache:
+    directories:
+    - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 
 language: java
 jdk:
+  - openjdk6
   - oraclejdk7
   - oraclejdk8
 


### PR DESCRIPTION
This very simple PR adds JDK 6, 7 and 8 builds to the travis-ci configuration. It also takes advantage of travis-ci's container support to enable caching dependencies, which should speed up builds a bit.

If we are eventually able to enable unit tests by default, this will provide coverage across all java versions that LittleProxy supports.