### PR TITLE
Use hamcrest in unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,18 @@
       <version>3.1</version>
     </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+          <exclusions>
+              <exclusion>
+                  <groupId>org.hamcrest</groupId>
+                  <artifactId>hamcrest-core</artifactId>
+              </exclusion>
+          </exclusions>
+      </dependency>
 
       <dependency>
           <groupId>org.hamcrest</groupId>
@@ -110,12 +116,18 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.0.5-beta</version>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <version>2.0.5-beta</version>
+          <scope>test</scope>
+          <exclusions>
+              <exclusion>
+                  <groupId>org.hamcrest</groupId>
+                  <artifactId>hamcrest-core</artifactId>
+              </exclusion>
+          </exclusions>
+      </dependency>
 
     <dependency>
       <groupId>org.mock-server</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,16 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
+
+      <dependency>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-junit</artifactId>
+          <version>2.0.0.0</version>
+          <scope>test</scope>
+      </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/src/test/java/org/littleshoot/proxy/AbstractProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/AbstractProxyTest.java
@@ -1,17 +1,6 @@
 package org.littleshoot.proxy;
 
-import static org.junit.Assert.*;
 import io.netty.handler.codec.http.HttpRequest;
-
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.security.cert.X509Certificate;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -33,6 +22,18 @@ import org.eclipse.jetty.server.Server;
 import org.junit.After;
 import org.junit.Before;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * Base for tests that test the proxy. This base class encapsulates all of the
@@ -153,7 +154,7 @@ public abstract class AbstractProxyTest {
     }
 
     protected void assertReceivedBadGateway(ResponseInfo response) {
-        assertTrue("Received: " + response, response.getStatusCode() == 502);
+        assertEquals("Received: " + response, 502, response.getStatusCode());
     }
 
     protected ResponseInfo httpPostWithApacheClient(
@@ -320,16 +321,16 @@ public abstract class AbstractProxyTest {
         if (isHTTPS && !isChained()) {
             numberOfExpectedServerInteractions -= 1;
         }
-        assertTrue(bytesReceivedFromClient.get() > 0);
+        assertThat(bytesReceivedFromClient.get(), greaterThan(0));
         assertEquals(numberOfExpectedClientInteractions,
                 requestsReceivedFromClient.get());
-        assertTrue(bytesSentToServer.get() > 0);
+        assertThat(bytesSentToServer.get(), greaterThan(0));
         assertEquals(numberOfExpectedServerInteractions,
                 requestsSentToServer.get());
-        assertTrue(bytesReceivedFromServer.get() > 0);
+        assertThat(bytesReceivedFromServer.get(), greaterThan(0));
         assertEquals(numberOfExpectedServerInteractions,
                 responsesReceivedFromServer.get());
-        assertTrue(bytesSentToClient.get() > 0);
+        assertThat(bytesSentToClient.get(), greaterThan(0));
         assertEquals(numberOfExpectedClientInteractions,
                 responsesSentToClient.get());
     }

--- a/src/test/java/org/littleshoot/proxy/BaseChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BaseChainedProxyTest.java
@@ -1,17 +1,19 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.HttpRequest;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Assert;
-import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * Base class for tests that test a proxy chained to an upstream proxy. In
@@ -114,16 +116,15 @@ public abstract class BaseChainedProxyTest extends BaseProxyTest {
     }
 
     private void assertThatUpstreamProxyReceivedSentRequests() {
-        Assert.assertEquals(
+        assertEquals(
                 "Upstream proxy should have seen every request sent by downstream proxy",
                 REQUESTS_SENT_BY_DOWNSTREAM.get(),
                 REQUESTS_RECEIVED_BY_UPSTREAM.get());
-        Assert.assertEquals(
+        assertEquals(
                 "1 and only 1 transport protocol should have been used to upstream proxy",
                 1, TRANSPORTS_USED.size());
-        Assert.assertTrue("Correct transport should have been used",
-                TRANSPORTS_USED.contains(newChainedProxy()
-                        .getTransportProtocol()));
+        assertThat("Correct transport should have been used",
+                newChainedProxy().getTransportProtocol(), is(in(TRANSPORTS_USED)));
     }
 
     protected class BaseChainedProxy extends ChainedProxyAdapter {

--- a/src/test/java/org/littleshoot/proxy/EndToEndStoppingTest.java
+++ b/src/test/java/org/littleshoot/proxy/EndToEndStoppingTest.java
@@ -25,8 +25,9 @@ import org.slf4j.LoggerFactory;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
@@ -190,7 +191,7 @@ public class EndToEndStoppingTest {
         final String source = driver.getPageSource();
 
         // Just make sure it got something within reason.
-        assertTrue(source.length() > 100);
+        assertThat(source.length(), greaterThan(100));
         driver.close();
 
         proxyServer.stop();

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLongArray;
 
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
@@ -108,28 +109,17 @@ public class HttpFilterTest {
                 new LinkedList<HttpRequest>();
 
         final AtomicInteger requestCount = new AtomicInteger(0);
-        final long[] proxyToServerRequestSendingNanos = new long[] { -1, -1,
-                -1, -1, -1 };
-        final long[] proxyToServerRequestSentNanos = new long[] { -1, -1, -1,
-                -1, -1 };
-        final long[] serverToProxyResponseReceivingNanos = new long[] { -1, -1,
-                -1, -1, -1 };
-        final long[] serverToProxyResponseReceivedNanos = new long[] { -1, -1,
-                -1, -1, -1 };
-        final long[] proxyToServerConnectionQueuedNanos = new long[] { -1, -1,
-                -1, -1, -1 };
-        final long[] proxyToServerResolutionStartedNanos = new long[] { -1, -1,
-                -1, -1, -1 };
-        final long[] proxyToServerResolutionSucceededNanos = new long[] { -1,
-                -1, -1, -1, -1 };
-        final long[] proxyToServerConnectionStartedNanos = new long[] { -1, -1,
-                -1, -1, -1 };
-        final long[] proxyToServerConnectionSSLHandshakeStartedNanos = new long[] {
-                -1, -1, -1, -1, -1 };
-        final long[] proxyToServerConnectionFailedNanos = new long[] { -1, -1,
-                -1, -1, -1 };
-        final long[] proxyToServerConnectionSucceededNanos = new long[] { -1,
-                -1, -1, -1, -1 };
+        final AtomicLongArray proxyToServerRequestSendingNanos = new AtomicLongArray(new long[] { -1, -1, -1, -1, -1 });
+        final AtomicLongArray proxyToServerRequestSentNanos = new AtomicLongArray(new long[] { -1, -1, -1,-1, -1 });
+        final AtomicLongArray serverToProxyResponseReceivingNanos = new AtomicLongArray(new long[] { -1, -1,-1, -1, -1 });
+        final AtomicLongArray serverToProxyResponseReceivedNanos = new AtomicLongArray(new long[] { -1, -1,-1, -1, -1 });
+        final AtomicLongArray proxyToServerConnectionQueuedNanos = new AtomicLongArray(new long[] { -1, -1,-1, -1, -1 });
+        final AtomicLongArray proxyToServerResolutionStartedNanos = new AtomicLongArray(new long[] { -1, -1,-1, -1, -1 });
+        final AtomicLongArray proxyToServerResolutionSucceededNanos = new AtomicLongArray(new long[] { -1,-1, -1, -1, -1 });
+        final AtomicLongArray proxyToServerConnectionStartedNanos = new AtomicLongArray(new long[] { -1, -1,-1, -1, -1 });
+        final AtomicLongArray proxyToServerConnectionSSLHandshakeStartedNanos = new AtomicLongArray(new long[] {-1, -1, -1, -1, -1 });
+        final AtomicLongArray proxyToServerConnectionFailedNanos = new AtomicLongArray(new long[] { -1, -1,-1, -1, -1 });
+        final AtomicLongArray proxyToServerConnectionSucceededNanos = new AtomicLongArray(new long[] { -1,-1, -1, -1, -1 });
 
         final String url1 = "http://localhost:" + webServerPort + "/";
         final String url2 = "http://localhost:" + webServerPort + "/testing";
@@ -173,12 +163,12 @@ public class HttpFilterTest {
 
                     @Override
                     public void proxyToServerRequestSending() {
-                        proxyToServerRequestSendingNanos[requestCount.get()] = now();
+                        proxyToServerRequestSendingNanos.set(requestCount.get(), now());
                     }
 
                     @Override
                     public void proxyToServerRequestSent() {
-                        proxyToServerRequestSentNanos[requestCount.get()] = now();
+                        proxyToServerRequestSentNanos.set(requestCount.get(), now());
                     }
 
                     public HttpObject serverToProxyResponse(
@@ -201,12 +191,12 @@ public class HttpFilterTest {
 
                     @Override
                     public void serverToProxyResponseReceiving() {
-                        serverToProxyResponseReceivingNanos[requestCount.get()] = now();
+                        serverToProxyResponseReceivingNanos.set(requestCount.get(), now());
                     }
 
                     @Override
                     public void serverToProxyResponseReceived() {
-                        serverToProxyResponseReceivedNanos[requestCount.get()] = now();
+                        serverToProxyResponseReceivedNanos.set(requestCount.get(), now());
                     }
 
                     public HttpObject proxyToClientResponse(
@@ -225,45 +215,41 @@ public class HttpFilterTest {
 
                     @Override
                     public void proxyToServerConnectionQueued() {
-                        proxyToServerConnectionQueuedNanos[requestCount.get()] = now();
+                        proxyToServerConnectionQueuedNanos.set(requestCount.get(), now());
                     }
 
                     @Override
                     public InetSocketAddress proxyToServerResolutionStarted(
                             String resolvingServerHostAndPort) {
-                        proxyToServerResolutionStartedNanos[requestCount.get()] = now();
-                        return super
-                                .proxyToServerResolutionStarted(resolvingServerHostAndPort);
+                        proxyToServerResolutionStartedNanos.set(requestCount.get(), now());
+                        return super.proxyToServerResolutionStarted(resolvingServerHostAndPort);
                     }
 
                     @Override
                     public void proxyToServerResolutionSucceeded(
                             String serverHostAndPort,
                             InetSocketAddress resolvedRemoteAddress) {
-                        proxyToServerResolutionSucceededNanos[requestCount
-                                .get()] = now();
+                        proxyToServerResolutionSucceededNanos.set(requestCount.get(), now());
                     }
 
                     @Override
                     public void proxyToServerConnectionStarted() {
-                        proxyToServerConnectionStartedNanos[requestCount.get()] = now();
+                        proxyToServerConnectionStartedNanos.set(requestCount.get(), now());
                     }
 
                     @Override
                     public void proxyToServerConnectionSSLHandshakeStarted() {
-                        proxyToServerConnectionSSLHandshakeStartedNanos[requestCount
-                                .get()] = now();
+                        proxyToServerConnectionSSLHandshakeStartedNanos.set(requestCount.get(), now());
                     }
 
                     @Override
                     public void proxyToServerConnectionFailed() {
-                        proxyToServerConnectionFailedNanos[requestCount.get()] = now();
+                        proxyToServerConnectionFailedNanos.set(requestCount.get(), now());
                     }
 
                     @Override
                     public void proxyToServerConnectionSucceeded() {
-                        proxyToServerConnectionSucceededNanos[requestCount
-                                .get()] = now();
+                        proxyToServerConnectionSucceededNanos.set(requestCount.get(), now());
                     }
 
                 };
@@ -281,7 +267,8 @@ public class HttpFilterTest {
         setUpHttpProxyServer(filtersSource);
 
         org.apache.http.HttpResponse response1 = getResponse(url1);
-        requestCount.incrementAndGet();
+        // sleep for a short amount of time, to allow the filter methods to be invoked
+        Thread.sleep(500);
         assertEquals(
                 "Response should have included the custom header from our pre filter",
                 "1", response1.getFirstHeader("Header-Pre").getValue());
@@ -295,22 +282,24 @@ public class HttpFilterTest {
         assertEquals(1, fullHttpResponsesReceived.get());
         assertEquals(1, filterResponseCalls.get());
 
-        int i = 0;
-        assertThat(proxyToServerConnectionQueuedNanos[i], lessThan(proxyToServerResolutionStartedNanos[i]));
-        assertThat(proxyToServerResolutionStartedNanos[i], lessThan(proxyToServerResolutionSucceededNanos[i]));
-        assertThat(proxyToServerResolutionSucceededNanos[i], lessThan(proxyToServerConnectionStartedNanos[i]));
-        assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos[i]);
-        assertEquals(-1, proxyToServerConnectionFailedNanos[i]);
-        assertThat(proxyToServerConnectionStartedNanos[i], lessThan(proxyToServerConnectionSucceededNanos[i]));
-        assertThat(proxyToServerConnectionSucceededNanos[i], lessThan(proxyToServerRequestSendingNanos[i]));
-        assertThat(proxyToServerRequestSendingNanos[i], lessThan(proxyToServerRequestSentNanos[i]));
-        assertThat(proxyToServerRequestSentNanos[i], lessThan(serverToProxyResponseReceivingNanos[i]));
-        assertThat(serverToProxyResponseReceivingNanos[i], lessThan(serverToProxyResponseReceivedNanos[i]));
+        int i = requestCount.get();
+        assertThat(proxyToServerConnectionQueuedNanos.get(i), lessThan(proxyToServerResolutionStartedNanos.get(i)));
+        assertThat(proxyToServerResolutionStartedNanos.get(i), lessThan(proxyToServerResolutionSucceededNanos.get(i)));
+        assertThat(proxyToServerResolutionSucceededNanos.get(i), lessThan(proxyToServerConnectionStartedNanos.get(i)));
+        assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos.get(i));
+        assertEquals(-1, proxyToServerConnectionFailedNanos.get(i));
+        assertThat(proxyToServerConnectionStartedNanos.get(i), lessThan(proxyToServerConnectionSucceededNanos.get(i)));
+        assertThat(proxyToServerConnectionSucceededNanos.get(i), lessThan(proxyToServerRequestSendingNanos.get(i)));
+        assertThat(proxyToServerRequestSendingNanos.get(i), lessThan(proxyToServerRequestSentNanos.get(i)));
+        assertThat(proxyToServerRequestSentNanos.get(i), lessThan(serverToProxyResponseReceivingNanos.get(i)));
+        assertThat(serverToProxyResponseReceivingNanos.get(i), lessThan(serverToProxyResponseReceivedNanos.get(i)));
 
         // We just open a second connection here since reusing the original
         // connection is inconsistent.
-        org.apache.http.HttpResponse response2 = getResponse(url2);
         requestCount.incrementAndGet();
+        org.apache.http.HttpResponse response2 = getResponse(url2);
+        Thread.sleep(500);
+
         assertEquals(403, response2.getStatusLine().getStatusCode());
 
         assertEquals(2, associatedRequests.size());
@@ -319,8 +308,10 @@ public class HttpFilterTest {
         assertEquals(1, fullHttpResponsesReceived.get());
         assertEquals(1, filterResponseCalls.get());
 
-        org.apache.http.HttpResponse response3 = getResponse(url3);
         requestCount.incrementAndGet();
+        org.apache.http.HttpResponse response3 = getResponse(url3);
+        Thread.sleep(500);
+
         assertEquals(403, response3.getStatusLine().getStatusCode());
 
         assertEquals(3, associatedRequests.size());
@@ -329,17 +320,17 @@ public class HttpFilterTest {
         assertEquals(1, fullHttpResponsesReceived.get());
         assertEquals(1, filterResponseCalls.get());
 
-        i = 2;
-        assertThat(proxyToServerConnectionQueuedNanos[i], lessThan(proxyToServerResolutionStartedNanos[i]));
-        assertThat(proxyToServerResolutionStartedNanos[i], lessThan(proxyToServerResolutionSucceededNanos[i]));
-        assertEquals(-1, proxyToServerConnectionStartedNanos[i]);
-        assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos[i]);
-        assertEquals(-1, proxyToServerConnectionFailedNanos[i]);
-        assertEquals(-1, proxyToServerConnectionSucceededNanos[i]);
-        assertEquals(-1, proxyToServerRequestSendingNanos[i]);
-        assertEquals(-1, proxyToServerRequestSentNanos[i]);
-        assertEquals(-1, serverToProxyResponseReceivingNanos[i]);
-        assertEquals(-1, serverToProxyResponseReceivedNanos[i]);
+        i = requestCount.get();
+        assertThat(proxyToServerConnectionQueuedNanos.get(i), lessThan(proxyToServerResolutionStartedNanos.get(i)));
+        assertThat(proxyToServerResolutionStartedNanos.get(i), lessThan(proxyToServerResolutionSucceededNanos.get(i)));
+        assertEquals(-1, proxyToServerConnectionStartedNanos.get(i));
+        assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos.get(i));
+        assertEquals(-1, proxyToServerConnectionFailedNanos.get(i));
+        assertEquals(-1, proxyToServerConnectionSucceededNanos.get(i));
+        assertEquals(-1, proxyToServerRequestSendingNanos.get(i));
+        assertEquals(-1, proxyToServerRequestSentNanos.get(i));
+        assertEquals(-1, serverToProxyResponseReceivingNanos.get(i));
+        assertEquals(-1, serverToProxyResponseReceivedNanos.get(i));
 
         final HttpRequest first = associatedRequests.remove();
         final HttpRequest second = associatedRequests.remove();
@@ -351,19 +342,23 @@ public class HttpFilterTest {
         assertEquals(url2, second.getUri());
         assertEquals(url3, third.getUri());
 
+        requestCount.incrementAndGet();
         org.apache.http.HttpResponse response4 = getResponse(url4);
-        i = 3;
-        assertThat(proxyToServerConnectionQueuedNanos[i], lessThan(proxyToServerResolutionStartedNanos[i]));
-        assertThat(proxyToServerResolutionStartedNanos[i], lessThan(proxyToServerResolutionSucceededNanos[i]));
-        assertThat(proxyToServerResolutionSucceededNanos[i], lessThan(proxyToServerConnectionStartedNanos[i]));
-        assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos[i]);
-        assertEquals(-1, proxyToServerConnectionFailedNanos[i]);
-        assertThat(proxyToServerConnectionStartedNanos[i], lessThan(proxyToServerConnectionSucceededNanos[i]));
-        assertThat(proxyToServerConnectionSucceededNanos[i], lessThan(proxyToServerRequestSendingNanos[i]));
-        assertThat(proxyToServerRequestSendingNanos[i], lessThan(proxyToServerRequestSentNanos[i]));
-        assertThat(proxyToServerRequestSentNanos[i], lessThan(serverToProxyResponseReceivingNanos[i]));
-        assertThat(serverToProxyResponseReceivingNanos[i], lessThan(serverToProxyResponseReceivedNanos[i]));
+        Thread.sleep(500);
 
+        i = requestCount.get();
+        assertThat(proxyToServerConnectionQueuedNanos.get(i), lessThan(proxyToServerResolutionStartedNanos.get(i)));
+        assertThat(proxyToServerResolutionStartedNanos.get(i), lessThan(proxyToServerResolutionSucceededNanos.get(i)));
+        assertThat(proxyToServerResolutionSucceededNanos.get(i), lessThan(proxyToServerConnectionStartedNanos.get(i)));
+        assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos.get(i));
+        assertEquals(-1, proxyToServerConnectionFailedNanos.get(i));
+        assertThat(proxyToServerConnectionStartedNanos.get(i), lessThan(proxyToServerConnectionSucceededNanos.get(i)));
+        assertThat(proxyToServerConnectionSucceededNanos.get(i), lessThan(proxyToServerRequestSendingNanos.get(i)));
+        assertThat(proxyToServerRequestSendingNanos.get(i), lessThan(proxyToServerRequestSentNanos.get(i)));
+        assertThat(proxyToServerRequestSentNanos.get(i), lessThan(serverToProxyResponseReceivingNanos.get(i)));
+        assertThat(serverToProxyResponseReceivingNanos.get(i), lessThan(serverToProxyResponseReceivedNanos.get(i)));
+
+        requestCount.incrementAndGet();
         org.apache.http.HttpResponse response5 = getResponse(url5);
 
         assertEquals(403, response4.getStatusLine().getStatusCode());
@@ -444,6 +439,7 @@ public class HttpFilterTest {
         requestSentCallbackInvoked.set(false);
 
         getResponse("http://localhost:" + webServerPort + "/");
+        Thread.sleep(500);
 
         assertTrue("proxyToServerRequest callback was not invoked for LastHttpContent for GET", lastHttpContentProcessed.get());
         assertTrue("proxyToServerRequestSent callback was not invoked for GET", requestSentCallbackInvoked.get());

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -32,8 +32,10 @@ import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class HttpFilterTest {
@@ -280,14 +282,12 @@ public class HttpFilterTest {
 
         org.apache.http.HttpResponse response1 = getResponse(url1);
         requestCount.incrementAndGet();
-        assertTrue(
+        assertEquals(
                 "Response should have included the custom header from our pre filter",
-                "1".equals(response1.getFirstHeader("Header-Pre")
-                        .getValue()));
-        assertTrue(
+                "1", response1.getFirstHeader("Header-Pre").getValue());
+        assertEquals(
                 "Response should have included the custom header from our post filter",
-                "2".equals(response1.getFirstHeader("Header-Post")
-                        .getValue()));
+                "2", response1.getFirstHeader("Header-Post").getValue());
 
         assertEquals(1, associatedRequests.size());
         assertEquals(1, shouldFilterCalls.get());
@@ -296,16 +296,16 @@ public class HttpFilterTest {
         assertEquals(1, filterResponseCalls.get());
 
         int i = 0;
-        assertTrue(proxyToServerConnectionQueuedNanos[i] < proxyToServerResolutionStartedNanos[i]);
-        assertTrue(proxyToServerResolutionStartedNanos[i] < proxyToServerResolutionSucceededNanos[i]);
-        assertTrue(proxyToServerResolutionSucceededNanos[i] < proxyToServerConnectionStartedNanos[i]);
+        assertThat(proxyToServerConnectionQueuedNanos[i], lessThan(proxyToServerResolutionStartedNanos[i]));
+        assertThat(proxyToServerResolutionStartedNanos[i], lessThan(proxyToServerResolutionSucceededNanos[i]));
+        assertThat(proxyToServerResolutionSucceededNanos[i], lessThan(proxyToServerConnectionStartedNanos[i]));
         assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos[i]);
         assertEquals(-1, proxyToServerConnectionFailedNanos[i]);
-        assertTrue(proxyToServerConnectionStartedNanos[i] < proxyToServerConnectionSucceededNanos[i]);
-        assertTrue(proxyToServerConnectionSucceededNanos[i] < proxyToServerRequestSendingNanos[i]);
-        assertTrue(proxyToServerRequestSendingNanos[i] < proxyToServerRequestSentNanos[i]);
-        assertTrue(proxyToServerRequestSentNanos[i] < serverToProxyResponseReceivingNanos[i]);
-        assertTrue(serverToProxyResponseReceivingNanos[i] < serverToProxyResponseReceivedNanos[i]);
+        assertThat(proxyToServerConnectionStartedNanos[i], lessThan(proxyToServerConnectionSucceededNanos[i]));
+        assertThat(proxyToServerConnectionSucceededNanos[i], lessThan(proxyToServerRequestSendingNanos[i]));
+        assertThat(proxyToServerRequestSendingNanos[i], lessThan(proxyToServerRequestSentNanos[i]));
+        assertThat(proxyToServerRequestSentNanos[i], lessThan(serverToProxyResponseReceivingNanos[i]));
+        assertThat(serverToProxyResponseReceivingNanos[i], lessThan(serverToProxyResponseReceivedNanos[i]));
 
         // We just open a second connection here since reusing the original
         // connection is inconsistent.
@@ -330,8 +330,8 @@ public class HttpFilterTest {
         assertEquals(1, filterResponseCalls.get());
 
         i = 2;
-        assertTrue(proxyToServerConnectionQueuedNanos[i] < proxyToServerResolutionStartedNanos[i]);
-        assertTrue(proxyToServerResolutionStartedNanos[i] < proxyToServerResolutionSucceededNanos[i]);
+        assertThat(proxyToServerConnectionQueuedNanos[i], lessThan(proxyToServerResolutionStartedNanos[i]));
+        assertThat(proxyToServerResolutionStartedNanos[i], lessThan(proxyToServerResolutionSucceededNanos[i]));
         assertEquals(-1, proxyToServerConnectionStartedNanos[i]);
         assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos[i]);
         assertEquals(-1, proxyToServerConnectionFailedNanos[i]);
@@ -353,16 +353,16 @@ public class HttpFilterTest {
 
         org.apache.http.HttpResponse response4 = getResponse(url4);
         i = 3;
-        assertTrue(proxyToServerConnectionQueuedNanos[i] < proxyToServerResolutionStartedNanos[i]);
-        assertTrue(proxyToServerResolutionStartedNanos[i] < proxyToServerResolutionSucceededNanos[i]);
-        assertTrue(proxyToServerResolutionSucceededNanos[i] < proxyToServerConnectionStartedNanos[i]);
+        assertThat(proxyToServerConnectionQueuedNanos[i], lessThan(proxyToServerResolutionStartedNanos[i]));
+        assertThat(proxyToServerResolutionStartedNanos[i], lessThan(proxyToServerResolutionSucceededNanos[i]));
+        assertThat(proxyToServerResolutionSucceededNanos[i], lessThan(proxyToServerConnectionStartedNanos[i]));
         assertEquals(-1, proxyToServerConnectionSSLHandshakeStartedNanos[i]);
         assertEquals(-1, proxyToServerConnectionFailedNanos[i]);
-        assertTrue(proxyToServerConnectionStartedNanos[i] < proxyToServerConnectionSucceededNanos[i]);
-        assertTrue(proxyToServerConnectionSucceededNanos[i] < proxyToServerRequestSendingNanos[i]);
-        assertTrue(proxyToServerRequestSendingNanos[i] < proxyToServerRequestSentNanos[i]);
-        assertTrue(proxyToServerRequestSentNanos[i] < serverToProxyResponseReceivingNanos[i]);
-        assertTrue(serverToProxyResponseReceivingNanos[i] < serverToProxyResponseReceivedNanos[i]);
+        assertThat(proxyToServerConnectionStartedNanos[i], lessThan(proxyToServerConnectionSucceededNanos[i]));
+        assertThat(proxyToServerConnectionSucceededNanos[i], lessThan(proxyToServerRequestSendingNanos[i]));
+        assertThat(proxyToServerRequestSendingNanos[i], lessThan(proxyToServerRequestSentNanos[i]));
+        assertThat(proxyToServerRequestSentNanos[i], lessThan(serverToProxyResponseReceivingNanos[i]));
+        assertThat(serverToProxyResponseReceivingNanos[i], lessThan(serverToProxyResponseReceivedNanos[i]));
 
         org.apache.http.HttpResponse response5 = getResponse(url5);
 

--- a/src/test/java/org/littleshoot/proxy/HttpStreamingFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpStreamingFilterTest.java
@@ -12,12 +12,15 @@ import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.util.EntityUtils;
 import org.eclipse.jetty.server.Server;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
 
 public class HttpStreamingFilterTest {
     private Server webServer;
@@ -98,12 +101,12 @@ public class HttpStreamingFilterTest {
                 new HttpHost("127.0.0.1",
                         webServerPort), request);
 
-        Assert.assertEquals("Received 20000 bytes\n",
+        assertEquals("Received 20000 bytes\n",
                 EntityUtils.toString(response.getEntity()));
 
-        Assert.assertEquals("Filter should have seen only 1 HttpRequest", 1,
+        assertEquals("Filter should have seen only 1 HttpRequest", 1,
                 numberOfInitialRequestsFiltered.get());
-        Assert.assertTrue("Filter should have seen 1 or more chunks",
-                numberOfSubsequentChunksFiltered.get() >= 1);
+        assertThat("Filter should have seen 1 or more chunks",
+                numberOfSubsequentChunksFiltered.get(), greaterThanOrEqualTo(1));
     }
 }

--- a/src/test/java/org/littleshoot/proxy/IdleTest.java
+++ b/src/test/java/org/littleshoot/proxy/IdleTest.java
@@ -6,11 +6,12 @@ import java.net.URL;
 
 import org.eclipse.jetty.server.Server;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -82,11 +83,11 @@ public class IdleTest {
                 - initialFileDescriptors;
 
         double fdDeltaRatio = Math.abs(fdDeltaToClosed / fdDeltaToOpen);
-        Assert.assertTrue(
+        assertThat(
                 "Number of file descriptors after close should be much closer to initial value than number of file descriptors while open (+/- 1%).\n"
                         + "Initial file descriptors: " + initialFileDescriptors + "; file descriptors while connections open: " + fileDescriptorsWhileConnectionsOpen + "; "
                         + "file descriptors after connections closed: " + fileDescriptorsAfterConnectionsClosed + "\n"
                         + "Ratio of file descriptors after connections are closed to descriptors before connections were closed: " + fdDeltaRatio,
-                fdDeltaRatio < 0.01);
+                fdDeltaRatio, lessThan(0.01));
     }
 }

--- a/src/test/java/org/littleshoot/proxy/IdlingProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/IdlingProxyTest.java
@@ -1,8 +1,8 @@
 package org.littleshoot.proxy;
 
-import static org.junit.Assert.*;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests just a single basic proxy.
@@ -20,7 +20,7 @@ public class IdlingProxyTest extends AbstractProxyTest {
     public void testTimeout() throws Exception {
         ResponseInfo response = httpGetWithApacheClient(webHost, "/hang", true,
                 false);
-        assertTrue("Received: " + response, response.getStatusCode() == 504);
+        assertEquals("Received: " + response, 504, response.getStatusCode());
     }
 
 }

--- a/src/test/java/org/littleshoot/proxy/MitmProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmProxyTest.java
@@ -1,6 +1,10 @@
 package org.littleshoot.proxy;
 
-import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
 import org.littleshoot.proxy.extras.SelfSignedMitmManager;
 
 import java.nio.charset.Charset;
@@ -8,8 +12,9 @@ import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 /**
  * Tests just a single basic proxy running as a man in the middle.
@@ -134,23 +139,23 @@ public class MitmProxyTest extends BaseProxyTest {
     }
 
     private void assertMethodSeenInRequestFilters(HttpMethod method) {
-        assertTrue(method
-                + " should have been seen in clientToProxyRequest filter",
-                requestPreMethodsSeen.contains(method));
-        assertTrue(method
-                + " should have been seen in proxyToServerRequest filter",
-                requestPostMethodsSeen.contains(method));
+        assertThat(method
+                        + " should have been seen in clientToProxyRequest filter",
+                requestPreMethodsSeen, hasItem(method));
+        assertThat(method
+                        + " should have been seen in proxyToServerRequest filter",
+                requestPostMethodsSeen, hasItem(method));
     }
 
     private void assertMethodSeenInResponseFilters(HttpMethod method) {
-        assertTrue(
+        assertThat(
                 method
                         + " should have been seen as the original requests's method in serverToProxyResponse filter",
-                responsePreOriginalRequestMethodsSeen.contains(method));
-        assertTrue(
+                responsePreOriginalRequestMethodsSeen, hasItem(method));
+        assertThat(
                 method
                         + " should have been seen as the original requests's method in proxyToClientResponse filter",
-                responsePostOriginalRequestMethodsSeen.contains(method));
+                responsePostOriginalRequestMethodsSeen, hasItem(method));
     }
 
     private void assertResponseFromFiltersMatchesActualResponse() {

--- a/src/test/java/org/littleshoot/proxy/ThrottlingTest.java
+++ b/src/test/java/org/littleshoot/proxy/ThrottlingTest.java
@@ -11,7 +11,6 @@ import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.util.EntityUtils;
 import org.eclipse.jetty.server.Server;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -19,6 +18,12 @@ import org.junit.runners.MethodSorters;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.io.IOException;
+
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 @FixMethodOrder(MethodSorters.JVM)
 public class ThrottlingTest {
@@ -114,12 +119,12 @@ public class ThrottlingTest {
                         writeWebServerPort), request);
         long finish = System.currentTimeMillis();
 
-        Assert.assertEquals("Received " + largeData.length + " bytes\n",
+        assertEquals("Received " + largeData.length + " bytes\n",
                 EntityUtils.toString(response.getEntity()));
 
-        Assert.assertTrue("Expected throttled write to complete in approximately " + msToWriteThrottled + "ms" + " but took " + (finish - start) + "ms",
-                finish - start > msToWriteThrottled * (1 - ALLOWABLE_VARIATION)
-                        && (finish - start < msToWriteThrottled * (1 + ALLOWABLE_VARIATION)));
+        assertThat("Expected throttled write to complete in approximately " + msToWriteThrottled + "ms" + " but took " + (finish - start) + "ms",
+                (double)(finish - start), both(greaterThan(msToWriteThrottled * (1 - ALLOWABLE_VARIATION))).and(
+                        lessThan(msToWriteThrottled * (1 + ALLOWABLE_VARIATION))));
 
         proxyServer.stop();
     }
@@ -142,10 +147,11 @@ public class ThrottlingTest {
                         writeWebServerPort), request);
         long finish = System.currentTimeMillis();
 
-        Assert.assertEquals("Received " + largeData.length + " bytes\n",
+        assertEquals("Received " + largeData.length + " bytes\n",
                 EntityUtils.toString(response.getEntity()));
 
-        Assert.assertTrue("Unthrottled write took " + (finish - start) + "ms, but expected to complete in " + UNTRHOTTLED_REQUEST_TIME_MS + "ms", finish - start < UNTRHOTTLED_REQUEST_TIME_MS);
+        assertThat("Unthrottled write took " + (finish - start) + "ms, but expected to complete in " + UNTRHOTTLED_REQUEST_TIME_MS + "ms",
+                finish - start, lessThan((long) UNTRHOTTLED_REQUEST_TIME_MS));
 
         proxyServer.stop();
     }
@@ -177,9 +183,9 @@ public class ThrottlingTest {
 
         long finish = System.currentTimeMillis();
 
-        Assert.assertTrue("Expected throttled read to complete in approximately " + msToReadThrottled + "ms" + " but took " + (finish - start) + "ms",
-                finish - start > msToReadThrottled * (1 - ALLOWABLE_VARIATION)
-                        && (finish - start < msToReadThrottled * (1 + ALLOWABLE_VARIATION)));
+        assertThat("Expected throttled read to complete in approximately " + msToReadThrottled + "ms" + " but took " + (finish - start) + "ms",
+                (double)(finish - start), both(greaterThan(msToReadThrottled * (1 - ALLOWABLE_VARIATION)))
+                        .and(lessThan(msToReadThrottled * (1 + ALLOWABLE_VARIATION))));
 
         proxyServer.stop();
     }
@@ -210,7 +216,8 @@ public class ThrottlingTest {
 
         long finish = System.currentTimeMillis();
 
-        Assert.assertTrue("Unthrottled read took " + (finish - start) + "ms, but expected to complete in " + UNTRHOTTLED_REQUEST_TIME_MS + "ms", finish - start < UNTRHOTTLED_REQUEST_TIME_MS);
+        assertThat("Unthrottled read took " + (finish - start) + "ms, but expected to complete in " + UNTRHOTTLED_REQUEST_TIME_MS + "ms",
+                finish - start, lessThan((long)UNTRHOTTLED_REQUEST_TIME_MS));
 
         proxyServer.stop();
     }
@@ -262,9 +269,9 @@ public class ThrottlingTest {
 
         HttpClientUtils.closeQuietly(response);
 
-        Assert.assertTrue("Expected second read to take approximately half as long as first throttled read. First read took " + (firstFinish - firstStart) + "ms" + " but second read took " + (secondFinish - secondStart) + "ms",
-                (firstFinish - firstStart) / 2 > (secondFinish - secondStart) * (1 - ALLOWABLE_VARIATION)
-                        && ((firstFinish - firstStart) / 2 < (secondFinish - secondStart) * (1 + ALLOWABLE_VARIATION)));
+        assertThat("Expected second read to take approximately half as long as first throttled read. First read took " + (firstFinish - firstStart) + "ms" + " but second read took " + (secondFinish - secondStart) + "ms",
+                (double)(firstFinish - firstStart) / 2, both(greaterThan((secondFinish - secondStart) * (1 - ALLOWABLE_VARIATION)))
+                        .and(lessThan((secondFinish - secondStart) * (1 + ALLOWABLE_VARIATION))));
 
         proxyServer.stop();
     }
@@ -316,9 +323,9 @@ public class ThrottlingTest {
 
         HttpClientUtils.closeQuietly(response);
 
-        Assert.assertTrue("Expected second read to complete within " + UNTRHOTTLED_REQUEST_TIME_MS + "ms, without throttling. First read took "
+        assertThat("Expected second read to complete within " + UNTRHOTTLED_REQUEST_TIME_MS + "ms, without throttling. First read took "
                         + (firstFinish - firstStart) + "ms" + ". Second read took " + (secondFinish - secondStart) + "ms",
-                secondFinish - secondStart < UNTRHOTTLED_REQUEST_TIME_MS);
+                secondFinish - secondStart, lessThan((long) UNTRHOTTLED_REQUEST_TIME_MS));
 
         proxyServer.stop();
 

--- a/src/test/java/org/littleshoot/proxy/TimeoutTest.java
+++ b/src/test/java/org/littleshoot/proxy/TimeoutTest.java
@@ -18,8 +18,9 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
@@ -77,8 +78,8 @@ public class TimeoutTest {
         EntityUtils.consumeQuietly(response.getEntity());
 
         assertEquals("Expected to receive an HTTP 504 (Gateway Timeout) response after proxy did not receive a response within 1 second", 504, response.getStatusLine().getStatusCode());
-        assertTrue("Expected idle connection timeout to happen after approximately 1 second. Total time was: " + TimeUnit.MILLISECONDS.convert(stop - start, TimeUnit.NANOSECONDS) + "ms",
-                TimeUnit.SECONDS.convert(stop - start, TimeUnit.NANOSECONDS) < 2);
+        assertThat("Expected idle connection timeout to happen after approximately 1 second",
+                TimeUnit.MILLISECONDS.convert(stop - start, TimeUnit.NANOSECONDS), lessThan(2000L));
     }
 
     @Test
@@ -101,7 +102,7 @@ public class TimeoutTest {
         EntityUtils.consumeQuietly(response.getEntity());
 
         assertEquals("Expected to receive an HTTP 502 (Bad Gateway) response after proxy could not connect within 1 second", 502, response.getStatusLine().getStatusCode());
-        assertTrue("Expected connection timeout to happen after approximately 1 second. Total time was: " + TimeUnit.MILLISECONDS.convert(stop - start, TimeUnit.NANOSECONDS) + "ms",
-                TimeUnit.SECONDS.convert(stop - start, TimeUnit.NANOSECONDS) < 2);
+        assertThat("Expected connection timeout to happen after approximately 1 second",
+                TimeUnit.MILLISECONDS.convert(stop - start, TimeUnit.NANOSECONDS), lessThan(2000L));
     }
 }


### PR DESCRIPTION
Another unit test PR, this replaces assertTrue() calls with assertThat() using Hamcrest matchers. This provides more informative results when tests fail due to greater than/less than conditions (among others). For example, instead of seeing only:
```
HttpFilterTest.testFiltering:365 null
```

We now see:

```
Failed tests:
HttpFilterTest.testFiltering:365
Expected: a value less than <-1L>
but: <11897708424077L> was greater than <-1L>
```