### PR TITLE
Removed erroneous '.' in Via header

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -16,6 +16,7 @@ import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -42,21 +43,7 @@ public class ProxyUtils {
      */
     private static final String PATTERN_RFC1123 = "EEE, dd MMM yyyy HH:mm:ss zzz";
 
-    private static final String hostName;
-
-    static {
-        try {
-            final InetAddress localAddress = NetworkUtils.getLocalHost();
-            hostName = localAddress.getHostName();
-        } catch (final UnknownHostException e) {
-            LOG.error("Could not lookup host", e);
-            throw new IllegalStateException("Could not determine host!", e);
-        }
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Via: 1.1 ");
-        sb.append(hostName);
-        sb.append("\r\n");
-    }
+    private static final String hostName = getHostName();
 
     // Should never be constructed.
     private ProxyUtils() {
@@ -243,16 +230,16 @@ public class ProxyUtils {
     public static void addVia(final HttpMessage msg) {
         final StringBuilder sb = new StringBuilder();
         sb.append(msg.getProtocolVersion().majorVersion());
-        sb.append(".");
+        sb.append('.');
         sb.append(msg.getProtocolVersion().minorVersion());
-        sb.append(".");
+        sb.append(' ');
         sb.append(hostName);
         final List<String> vias;
         if (msg.headers().contains(HttpHeaders.Names.VIA)) {
             vias = msg.headers().getAll(HttpHeaders.Names.VIA);
             vias.add(sb.toString());
         } else {
-            vias = Arrays.asList(sb.toString());
+            vias = Collections.singletonList(sb.toString());
         }
         msg.headers().set(HttpHeaders.Names.VIA, vias);
     }
@@ -327,4 +314,19 @@ public class ProxyUtils {
                 && (str.equalsIgnoreCase(str1) || str.equalsIgnoreCase(str2));
     }
 
+    /**
+     * Attempts to resolve the local machine's hostname.
+     *
+     * @return the local machine's hostname
+     * @throws IllegalStateException if the hostname cannot be resolved
+     */
+    public static String getHostName() throws IllegalStateException {
+        try {
+            final InetAddress localAddress = NetworkUtils.getLocalHost();
+            return localAddress.getHostName();
+        } catch (final UnknownHostException e) {
+            LOG.error("Could not lookup host", e);
+            throw new IllegalStateException("Could not determine host!", e);
+        }
+    }
 }

--- a/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
@@ -1,9 +1,17 @@
 package org.littleshoot.proxy.impl;
 
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
-import static org.littleshoot.proxy.impl.ProxyUtils.*;
+import static org.junit.Assert.assertThat;
 
 /**
  * Test for proxy utilities.
@@ -12,12 +20,44 @@ public class ProxyUtilsTest {
 
     @Test
     public void testParseHostAndPort() throws Exception {
-        assertEquals("www.test.com:80", parseHostAndPort("http://www.test.com:80/test"));
-        assertEquals("www.test.com:80", parseHostAndPort("https://www.test.com:80/test"));
-        assertEquals("www.test.com:443", parseHostAndPort("https://www.test.com:443/test"));
-        assertEquals("www.test.com:80", parseHostAndPort("www.test.com:80/test"));
-        assertEquals("www.test.com", parseHostAndPort("http://www.test.com"));
-        assertEquals("www.test.com", parseHostAndPort("www.test.com"));
-        assertEquals("httpbin.org:443", parseHostAndPort("httpbin.org:443/get"));
+        assertEquals("www.test.com:80", ProxyUtils.parseHostAndPort("http://www.test.com:80/test"));
+        assertEquals("www.test.com:80", ProxyUtils.parseHostAndPort("https://www.test.com:80/test"));
+        assertEquals("www.test.com:443", ProxyUtils.parseHostAndPort("https://www.test.com:443/test"));
+        assertEquals("www.test.com:80", ProxyUtils.parseHostAndPort("www.test.com:80/test"));
+        assertEquals("www.test.com", ProxyUtils.parseHostAndPort("http://www.test.com"));
+        assertEquals("www.test.com", ProxyUtils.parseHostAndPort("www.test.com"));
+        assertEquals("httpbin.org:443", ProxyUtils.parseHostAndPort("httpbin.org:443/get"));
     }
+
+    @Test
+    public void testAddNewViaHeader() {
+        String hostname = ProxyUtils.getHostName();
+
+        HttpMessage httpMessage = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/endpoint");
+        ProxyUtils.addVia(httpMessage);
+
+        List<String> viaHeaders = httpMessage.headers().getAll(HttpHeaders.Names.VIA);
+        assertThat(viaHeaders, hasSize(1));
+
+        String expectedViaHeader = "1.1 " + hostname;
+        assertEquals(expectedViaHeader, viaHeaders.get(0));
+    }
+
+    @Test
+    public void testAddNewViaHeaderToExistingViaHeader() {
+        String hostname = ProxyUtils.getHostName();
+
+        HttpMessage httpMessage = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/endpoint");
+        httpMessage.headers().add(HttpHeaders.Names.VIA, "1.1 otherproxy");
+        ProxyUtils.addVia(httpMessage);
+
+        List<String> viaHeaders = httpMessage.headers().getAll(HttpHeaders.Names.VIA);
+        assertThat(viaHeaders, hasSize(2));
+
+        assertEquals("1.1 otherproxy", viaHeaders.get(0));
+
+        String expectedViaHeader = "1.1 " + hostname;
+        assertEquals(expectedViaHeader, viaHeaders.get(1));
+    }
+
 }


### PR DESCRIPTION
This PR fixes an error in the Via header that was not separating the HTTP protocol version from the hostname. This brings LP's Via header in line with the [HTTP spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45).

I plan to add support for using an alias instead of a hostname (as the spec allows) in a separate PR.