### PR TITLE
Do not remove Transfer-Encoding when included in Connection header

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -36,9 +36,9 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -78,10 +78,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     private static final HttpResponseStatus CONNECTION_ESTABLISHED = new HttpResponseStatus(
             200, "HTTP/1.1 200 Connection established");
 
-    private static final Set<String> HOP_BY_HOP_HEADERS = new HashSet<String>(
-            Arrays.asList(new String[] { "connection", "keep-alive",
-                    "proxy-authenticate", "proxy-authorization", "te",
-                    "trailers", "upgrade" }));
+    /**
+     * Used for case-insensitive comparisons when parsing Connection header values.
+     */
+    private static final String LOWERCASE_TRANSFER_ENCODING_HEADER = HttpHeaders.Names.TRANSFER_ENCODING.toLowerCase(Locale.US);
 
     /**
      * Keep track of all ProxyToServerConnections by host+port.
@@ -410,8 +410,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             LOG.debug("Responding with CONNECT successful");
             HttpResponse response = responseFor(HttpVersion.HTTP_1_1,
                     CONNECTION_ESTABLISHED);
-            response.headers().set("Connection", "Keep-Alive");
-            response.headers().set("Proxy-Connection", "Keep-Alive");
+            response.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+            response.headers().set("Proxy-Connection", HttpHeaders.Values.KEEP_ALIVE);
             ProxyUtils.addVia(response);
             return writeToChannel(response);
         };
@@ -892,10 +892,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                 + "the credentials required.</p>\n" + "</body></html>\n";
         DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED, body);
-        response.headers().set("Date", ProxyUtils.httpDate());
+        HttpHeaders.setDate(response, new Date());
         response.headers().set("Proxy-Authenticate",
                 "Basic realm=\"Restricted Files\"");
-        response.headers().set("Date", ProxyUtils.httpDate());
         write(response);
     }
 
@@ -980,6 +979,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             HttpResponse httpResponse) {
         if (!proxyServer.isTransparent()) {
             HttpHeaders headers = httpResponse.headers();
+
             stripConnectionTokens(headers);
             stripHopByHopHeaders(headers);
             ProxyUtils.addVia(httpResponse);
@@ -991,8 +991,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
              * assigned one by the recipient if the message will be cached by
              * that recipient or gatewayed via a protocol which requires a Date.
              */
-            if (!headers.contains("Date")) {
-                headers.set("Date", ProxyUtils.httpDate());
+            if (!headers.contains(HttpHeaders.Names.DATE)) {
+                HttpHeaders.setDate(httpResponse, new Date());
             }
         }
     }
@@ -1026,7 +1026,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         if (headers.contains(proxyConnectionKey)) {
             String header = headers.get(proxyConnectionKey);
             headers.remove(proxyConnectionKey);
-            headers.set("Connection", header);
+            headers.set(HttpHeaders.Names.CONNECTION, header);
         }
     }
 
@@ -1042,10 +1042,14 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      *            The headers to modify
      */
     private void stripConnectionTokens(HttpHeaders headers) {
-        if (headers.contains("Connection")) {
-            for (String headerValue : headers.getAll("Connection")) {
+        if (headers.contains(HttpHeaders.Names.CONNECTION)) {
+            for (String headerValue : headers.getAll(HttpHeaders.Names.CONNECTION)) {
                 for (String connectionToken : headerValue.split(",")) {
-                    headers.remove(connectionToken);
+                    // do not strip out the Transfer-Encoding header if it is specified in the Connection header, since LittleProxy does not
+                    // normally modify the Transfer-Encoding of the message.
+                    if (!LOWERCASE_TRANSFER_ENCODING_HEADER.equals(connectionToken.toLowerCase(Locale.US))) {
+                        headers.remove(connectionToken);
+                    }
                 }
             }
         }
@@ -1060,9 +1064,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private void stripHopByHopHeaders(HttpHeaders headers) {
         Set<String> headerNames = headers.names();
-        for (String name : headerNames) {
-            if (HOP_BY_HOP_HEADERS.contains(name.toLowerCase())) {
-                headers.remove(name);
+        for (String headerName : headerNames) {
+            if (ProxyUtils.shouldRemoveHopByHopHeader(headerName)) {
+                headers.remove(headerName);
             }
         }
     }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -77,7 +77,6 @@ import static org.littleshoot.proxy.impl.ConnectionState.NEGOTIATING_CONNECT;
 public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     private static final HttpResponseStatus CONNECTION_ESTABLISHED = new HttpResponseStatus(
             200, "HTTP/1.1 200 Connection established");
-
     /**
      * Used for case-insensitive comparisons when parsing Connection header values.
      */
@@ -1044,7 +1043,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     private void stripConnectionTokens(HttpHeaders headers) {
         if (headers.contains(HttpHeaders.Names.CONNECTION)) {
             for (String headerValue : headers.getAll(HttpHeaders.Names.CONNECTION)) {
-                for (String connectionToken : headerValue.split(",")) {
+                for (String connectionToken : ProxyUtils.splitCommaSeparatedHeaderValues(headerValue)) {
                     // do not strip out the Transfer-Encoding header if it is specified in the Connection header, since LittleProxy does not
                     // normally modify the Transfer-Encoding of the message.
                     if (!LOWERCASE_TRANSFER_ENCODING_HEADER.equals(connectionToken.toLowerCase(Locale.US))) {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -59,7 +59,7 @@ public class ProxyUtils {
     private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
 
     /**
-     * Splits comma-separated header values into their individual values.
+     * Splits comma-separated header values (such as Connection) into their individual tokens.
      */
     private static final Splitter COMMA_SEPARATED_HEADER_VALUE_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
@@ -467,7 +467,7 @@ public class ProxyUtils {
 
         ImmutableList.Builder<String> headerValues = ImmutableList.builder();
         for (String header : allHeaders) {
-            Iterable<String> commaSeparatedValues = COMMA_SEPARATED_HEADER_VALUE_SPLITTER.split(header);
+            List<String> commaSeparatedValues = splitCommaSeparatedHeaderValues(header);
             headerValues.addAll(commaSeparatedValues);
         }
 
@@ -528,5 +528,18 @@ public class ProxyUtils {
      */
     public static boolean shouldRemoveHopByHopHeader(String headerName) {
         return SHOULD_NOT_PROXY_HOP_BY_HOP_HEADERS.contains(headerName.toLowerCase(Locale.US));
+    }
+
+    /**
+     * Splits comma-separated header values into tokens. For example, if the value of the Connection header is "Transfer-Encoding, close",
+     * this method will return "Transfer-Encoding" and "close". This method strips trims any optional whitespace from
+     * the tokens. Unlike {@link #getAllCommaSeparatedHeaderValues(String, HttpMessage)}, this method only operates on
+     * a single header value, rather than all instances of the header in a message.
+     *
+     * @param headerValue the un-tokenized header value (must not be null)
+     * @return all tokens within the header value, or an empty list if there are no values
+     */
+    public static List<String> splitCommaSeparatedHeaderValues(String headerValue) {
+        return ImmutableList.copyOf(COMMA_SEPARATED_HEADER_VALUE_SPLITTER.split(headerValue));
     }
 }

--- a/src/test/java/org/littleshoot/proxy/ProxyHeadersTest.java
+++ b/src/test/java/org/littleshoot/proxy/ProxyHeadersTest.java
@@ -1,0 +1,94 @@
+package org.littleshoot.proxy;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.matchers.Times;
+import org.mockserver.model.ConnectionOptions;
+
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+/**
+ * Tests the proxy's handling and manipulation of headers.
+ */
+public class ProxyHeadersTest {
+    private HttpProxyServer proxyServer;
+
+    private ClientAndServer mockServer;
+    private int mockServerPort;
+
+    @Before
+    public void setUp() throws Exception {
+        mockServer = new ClientAndServer(0);
+        mockServerPort = mockServer.getPort();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            if (proxyServer != null) {
+                proxyServer.abort();
+            }
+        } finally {
+            if (mockServer != null) {
+                mockServer.stop();
+            }
+        }
+    }
+
+    @Test
+    public void testProxyRemovesConnectionHeadersFromServer() throws Exception {
+        // the proxy should remove all Connection headers, since it is a hop-by-hop header. however, since the proxy does not
+        // generally modify the Transfer-Encoding of the message, it should not remove the Transfer-Encoding header.
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/connectionheaders"),
+                Times.exactly(1))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withBody("success")
+                        .withHeader("Connection", "Transfer-Encoding, Dummy-Header")
+                        .withHeader("Transfer-Encoding", "identity")
+                        .withHeader("Dummy-Header", "dummy-value")
+                        .withConnectionOptions(new ConnectionOptions()
+                                .withSuppressConnectionHeader(true))
+                );
+
+        this.proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
+
+        HttpClient httpClient = TestUtils.createProxiedHttpClient(proxyServer.getListenAddress().getPort());
+        HttpResponse response = httpClient.execute(new HttpGet("http://localhost:" + mockServerPort + "/connectionheaders"));
+        EntityUtils.consume(response.getEntity());
+
+        Header[] dummyHeaders = response.getHeaders("Dummy-Header");
+        assertThat("Expected proxy to remove the Dummy-Header specified in the Connection header", dummyHeaders, emptyArray());
+
+        Header[] transferEncodingHeaders = response.getHeaders("Transfer-Encoding");
+        assertThat("Expected proxy to keep the Transfer-Encoding header, even when specified in the Connection header", transferEncodingHeaders, not(emptyArray()));
+
+        // make sure we find the "identity" header, which should not be removed
+        boolean foundIdentity = false;
+        for (Header transferEncodingHeader : transferEncodingHeaders) {
+            if ("identity".equals(transferEncodingHeader.getValue())) {
+                foundIdentity = true;
+                break;
+            }
+        }
+
+        assertTrue("Expected to find Transfer-Encoding: identity header value specified in response", foundIdentity);
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
@@ -203,4 +203,20 @@ public class ProxyUtilsTest {
         String expectedViaHeader = "1.1 " + hostname;
         assertEquals(expectedViaHeader, viaHeaders.get(1));
     }
+
+    @Test
+    public void testSplitCommaSeparatedHeaderValues() {
+        assertThat("Incorrect header tokens", ProxyUtils.splitCommaSeparatedHeaderValues("one"), contains("one"));
+        assertThat("Incorrect header tokens", ProxyUtils.splitCommaSeparatedHeaderValues("one,two,three"), contains("one", "two", "three"));
+        assertThat("Incorrect header tokens", ProxyUtils.splitCommaSeparatedHeaderValues("one, two, three"), contains("one", "two", "three"));
+        assertThat("Incorrect header tokens", ProxyUtils.splitCommaSeparatedHeaderValues(" one,two,  three "), contains("one", "two", "three"));
+        assertThat("Incorrect header tokens", ProxyUtils.splitCommaSeparatedHeaderValues("\t\tone ,\t two,  three\t"), contains("one", "two", "three"));
+
+        assertThat("Expected no header tokens", ProxyUtils.splitCommaSeparatedHeaderValues(""), empty());
+        assertThat("Expected no header tokens", ProxyUtils.splitCommaSeparatedHeaderValues(","), empty());
+        assertThat("Expected no header tokens", ProxyUtils.splitCommaSeparatedHeaderValues(" "), empty());
+        assertThat("Expected no header tokens", ProxyUtils.splitCommaSeparatedHeaderValues("\t"), empty());
+        assertThat("Expected no header tokens", ProxyUtils.splitCommaSeparatedHeaderValues("  \t  \t  "), empty());
+        assertThat("Expected no header tokens", ProxyUtils.splitCommaSeparatedHeaderValues(" ,  ,\t, "), empty());
+    }
 }


### PR DESCRIPTION
Normally LittleProxy removes all headers specified in the Connection header, as required by the HTTP 1.1 spec, [section 14.10](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10):
> HTTP/1.1 proxies MUST parse the Connection header field before a message is forwarded and, for each connection-token in this field, remove any header field(s) from the message with the same name as the connection-token.

A problem arises when the Transfer-Encoding header name is included in the Connection header's values, as it is at weather.com and some other sites. Since LittleProxy doesn't generally modify a message's chunking, the Transfer-Encoding header should not normally be removed, even if it is included in the Connection header values.

This fix also replaces some hard-coded header strings with netty's HttpHeaders.Names constants, and standardizes lowercasing to Locale.US, to avoid rare locale-specific bugs.

This fix includes PR #197 to make merging easier, so that PR should be merged first.