### PR TITLE
Added maven-assembly-plugin for building fat-jar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ $ cd LittleProxy
 $ ./run.bash
 ```
 
+A fat jar (with dependencies) can be built through maven as follows:
+```
+mvn assembly:single
+```
+
 You can embed LittleProxy in your own projects through maven with the following:
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,15 @@
 
     <plugins>
       <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <version>1.4.7</version>


### PR DESCRIPTION
It is handy for the guys who want to use latest version of LittleProxy.