### PR TITLE
Including MitmManager in new proxy when cloning

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -679,6 +679,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             this.authenticateSslClients = authenticateSslClients;
             this.proxyAuthenticator = proxyAuthenticator;
             this.chainProxyManager = chainProxyManager;
+            this.mitmManager = mitmManager;
             this.filtersSource = filtersSource;
             this.transparent = transparent;
             this.idleConnectionTimeout = idleConnectionTimeout;


### PR DESCRIPTION
This fixes a minor issue where the MitmManager was not set when cloning the proxy.