### PR TITLE
Add Transfer-Encoding: chunked and avoid closing connections when possible

### DIFF
--- a/src/test/java/org/littleshoot/proxy/MessageTerminationTest.java
+++ b/src/test/java/org/littleshoot/proxy/MessageTerminationTest.java
@@ -1,0 +1,196 @@
+package org.littleshoot.proxy;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.matchers.Times;
+import org.mockserver.model.ConnectionOptions;
+
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public class MessageTerminationTest {
+    private ClientAndServer mockServer;
+    private int mockServerPort;
+    private HttpProxyServer proxyServer;
+
+    @Before
+    public void setUp() {
+        mockServer = new ClientAndServer(0);
+        mockServerPort = mockServer.getPort();
+    }
+
+    @After
+    public void tearDown() {
+        if (mockServer != null) {
+            mockServer.stop();
+        }
+
+        if (proxyServer != null) {
+            proxyServer.abort();
+        }
+    }
+
+    @Test
+    public void testResponseWithoutTerminationIsChunked() throws Exception {
+        // set up the server so that it indicates the end of the response by closing the connection. the proxy
+        // should automatically add the Transfer-Encoding: chunked header when sending to the client.
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/"),
+                Times.unlimited())
+                .respond(response()
+                                .withStatusCode(200)
+                                .withBody("Success!")
+                                .withConnectionOptions(new ConnectionOptions()
+                                        .withCloseSocket(true)
+                                        .withSuppressConnectionHeader(true)
+                                        .withSuppressContentLengthHeader(true))
+                );
+
+        proxyServer = DefaultHttpProxyServer.bootstrap().start();
+        int proxyServerPort = proxyServer.getListenAddress().getPort();
+
+        HttpClient httpClient = TestUtils.createProxiedHttpClient(proxyServerPort);
+        HttpResponse response = httpClient.execute(new HttpGet("http://127.0.0.1:" + mockServerPort + "/"));
+
+        assertEquals("Expected to receive a 200 from the server", 200, response.getStatusLine().getStatusCode());
+
+        // verify the Transfer-Encoding header was added
+        Header[] transferEncodingHeaders = response.getHeaders("Transfer-Encoding");
+        assertThat("Expected to see a Transfer-Encoding header", transferEncodingHeaders.length, greaterThanOrEqualTo(1));
+        String transferEncoding = transferEncodingHeaders[0].getValue();
+        assertEquals("Expected Transfer-Encoding to be chunked", "chunked", transferEncoding);
+
+        String bodyString = EntityUtils.toString(response.getEntity(), "ISO-8859-1");
+        response.getEntity().getContent().close();
+
+        assertEquals("Success!", bodyString);
+    }
+
+    @Test
+    public void testResponseWithContentLengthNotModified() throws Exception {
+        // the proxy should not modify the response since it contains a Content-Length header.
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/"),
+                Times.unlimited())
+                .respond(response()
+                                .withStatusCode(200)
+                                .withBody("Success!")
+                                .withConnectionOptions(new ConnectionOptions()
+                                        .withCloseSocket(true)
+                                        .withSuppressConnectionHeader(true))
+                );
+
+        proxyServer = DefaultHttpProxyServer.bootstrap().start();
+        int proxyServerPort = proxyServer.getListenAddress().getPort();
+
+        HttpClient httpClient = TestUtils.createProxiedHttpClient(proxyServerPort);
+        HttpResponse response = httpClient.execute(new HttpGet("http://127.0.0.1:" + mockServerPort + "/"));
+
+        assertEquals("Expected to receive a 200 from the server", 200, response.getStatusLine().getStatusCode());
+
+        // verify the Transfer-Encoding header was NOT added
+        Header[] transferEncodingHeaders = response.getHeaders("Transfer-Encoding");
+        assertThat("Did not expect to see a Transfer-Encoding header", transferEncodingHeaders, emptyArray());
+
+        String bodyString = EntityUtils.toString(response.getEntity(), "ISO-8859-1");
+        response.getEntity().getContent().close();
+
+        assertEquals("Success!", bodyString);
+    }
+
+    @Test
+    public void testFilterAddsContentLength() throws Exception {
+        // when a filter with buffering is added to the filter chain, the aggregated FullHttpResponse should
+        // automatically have a Content-Length header
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/"),
+                Times.unlimited())
+                .respond(response()
+                                .withStatusCode(200)
+                                .withBody("Success!")
+                                .withConnectionOptions(new ConnectionOptions()
+                                        .withCloseSocket(true)
+                                        .withSuppressConnectionHeader(true)
+                                        .withSuppressContentLengthHeader(true))
+                );
+
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withFiltersSource(new HttpFiltersSourceAdapter() {
+                    @Override
+                    public int getMaximumResponseBufferSizeInBytes() {
+                        return 100000;
+                    }
+                })
+                .start();
+        int proxyServerPort = proxyServer.getListenAddress().getPort();
+
+
+        HttpClient httpClient = TestUtils.createProxiedHttpClient(proxyServerPort);
+        HttpResponse response = httpClient.execute(new HttpGet("http://127.0.0.1:" + mockServerPort + "/"));
+
+        assertEquals("Expected to receive a 200 from the server", 200, response.getStatusLine().getStatusCode());
+
+        // verify the Transfer-Encoding header was NOT added
+        Header[] transferEncodingHeaders = response.getHeaders("Transfer-Encoding");
+        assertThat("Did not expect to see a Transfer-Encoding header", transferEncodingHeaders, emptyArray());
+
+        Header[] contentLengthHeaders = response.getHeaders("Content-Length");
+        assertThat("Expected to see a Content-Length header", contentLengthHeaders.length, greaterThanOrEqualTo(1));
+
+        String bodyString = EntityUtils.toString(response.getEntity(), "ISO-8859-1");
+        response.getEntity().getContent().close();
+
+        assertEquals("Success!", bodyString);
+    }
+
+    @Test
+    public void testResponseToHEADNotModified() throws Exception {
+        // the proxy should not modify the response since it is an HTTP HEAD request
+        mockServer.when(request()
+                        .withMethod("HEAD")
+                        .withPath("/"),
+                Times.unlimited())
+                .respond(response()
+                                .withStatusCode(200)
+                                .withConnectionOptions(new ConnectionOptions()
+                                        .withCloseSocket(false)
+                                        .withSuppressConnectionHeader(true)
+                                        .withSuppressContentLengthHeader(true))
+                );
+
+        proxyServer = DefaultHttpProxyServer.bootstrap().start();
+        int proxyServerPort = proxyServer.getListenAddress().getPort();
+
+        HttpClient httpClient = TestUtils.createProxiedHttpClient(proxyServerPort);
+        HttpResponse response = httpClient.execute(new HttpHead("http://127.0.0.1:" + mockServerPort + "/"));
+
+        assertEquals("Expected to receive a 200 from the server", 200, response.getStatusLine().getStatusCode());
+
+        // verify the Transfer-Encoding header was NOT added
+        Header[] transferEncodingHeaders = response.getHeaders("Transfer-Encoding");
+        assertThat("Did not expect to see a Transfer-Encoding header", transferEncodingHeaders, emptyArray());
+
+        // verify the Content-Length header was not added
+        Header[] contentLengthHeaders = response.getHeaders("Content-Length");
+        assertThat("Did not expect to see a Content-Length header", contentLengthHeaders, emptyArray());
+
+        assertNull("Expected response to HEAD to have no entity body", response.getEntity());
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/MessageTerminationTest.java
+++ b/src/test/java/org/littleshoot/proxy/MessageTerminationTest.java
@@ -61,7 +61,9 @@ public class MessageTerminationTest {
                                         .withSuppressContentLengthHeader(true))
                 );
 
-        proxyServer = DefaultHttpProxyServer.bootstrap().start();
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
         int proxyServerPort = proxyServer.getListenAddress().getPort();
 
         HttpClient httpClient = TestUtils.createProxiedHttpClient(proxyServerPort);
@@ -96,7 +98,9 @@ public class MessageTerminationTest {
                                         .withSuppressConnectionHeader(true))
                 );
 
-        proxyServer = DefaultHttpProxyServer.bootstrap().start();
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
         int proxyServerPort = proxyServer.getListenAddress().getPort();
 
         HttpClient httpClient = TestUtils.createProxiedHttpClient(proxyServerPort);
@@ -138,6 +142,7 @@ public class MessageTerminationTest {
                         return 100000;
                     }
                 })
+                .withPort(0)
                 .start();
         int proxyServerPort = proxyServer.getListenAddress().getPort();
 
@@ -175,7 +180,9 @@ public class MessageTerminationTest {
                                         .withSuppressContentLengthHeader(true))
                 );
 
-        proxyServer = DefaultHttpProxyServer.bootstrap().start();
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
         int proxyServerPort = proxyServer.getListenAddress().getPort();
 
         HttpClient httpClient = TestUtils.createProxiedHttpClient(proxyServerPort);

--- a/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
@@ -1,9 +1,20 @@
 package org.littleshoot.proxy.impl;
 
+import io.netty.handler.codec.http.DefaultHttpMessage;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
-import static org.littleshoot.proxy.impl.ProxyUtils.*;
+import static org.junit.Assert.assertThat;
+import static org.littleshoot.proxy.impl.ProxyUtils.parseHostAndPort;
 
 /**
  * Test for proxy utilities.
@@ -19,5 +30,143 @@ public class ProxyUtilsTest {
         assertEquals("www.test.com", parseHostAndPort("http://www.test.com"));
         assertEquals("www.test.com", parseHostAndPort("www.test.com"));
         assertEquals("httpbin.org:443", parseHostAndPort("httpbin.org:443/get"));
+    }
+
+    @Test
+    public void testCommaSeparatedHeaderValues() {
+        DefaultHttpMessage message;
+        List<String> commaSeparatedHeaders;
+
+        // test the empty headers case
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, empty());
+
+        // two headers present, but no values
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "");
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "");
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, empty());
+
+        // a single header value
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "chunked");
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, contains("chunked"));
+
+        // a single header value with extra spaces
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, " chunked  , ");
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, contains("chunked"));
+
+        // two comma-separated values in one header line
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "compress, gzip");
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, contains("compress", "gzip"));
+
+        // two comma-separated values in one header line with a spurious ',' and space. see RFC 7230 section 7
+        // for information on empty list items (not all of which are valid header-values).
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "compress, gzip, ,");
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, contains("compress", "gzip"));
+
+        // two values in two separate header lines
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "gzip");
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "chunked");
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, contains("gzip", "chunked"));
+
+        // multiple comma-separated values in two separate header lines
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "gzip, compress");
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "deflate, gzip");
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, contains("gzip", "compress", "deflate", "gzip"));
+
+        // multiple comma-separated values in multiple header lines with spurious spaces, commas,
+        // and tabs (horizontal tabs are defined as optional whitespace in RFC 7230 section 3.2.3)
+        message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, " gzip,compress,");
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "\tdeflate\t,  gzip, ");
+        message.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, ",gzip,,deflate,\t, ,");
+        commaSeparatedHeaders = ProxyUtils.getAllCommaSeparatedHeaderValues(HttpHeaders.Names.TRANSFER_ENCODING, message);
+        assertThat(commaSeparatedHeaders, contains("gzip", "compress", "deflate", "gzip", "gzip", "deflate"));
+    }
+
+    @Test
+    public void testIsResponseSelfTerminating() {
+        HttpResponse httpResponse;
+        boolean isResponseSelfTerminating;
+
+        // test cases from the scenarios listed in RFC 2616, section 4.4
+        // #1: 1.Any response message which "MUST NOT" include a message-body (such as the 1xx, 204, and 304 responses and any response to a HEAD request) is always terminated by the first empty line after the header fields, regardless of the entity-header fields present in the message.
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE);
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        // #2: 2.If a Transfer-Encoding header field (section 14.41) is present and has any value other than "identity", then the transfer-length is defined by use of the "chunked" transfer-coding (section 3.6), unless the message is terminated by closing the connection.
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "chunked");
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "gzip, chunked");
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        // chunked encoding is not last, so not self terminating
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "chunked, gzip");
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(false, isResponseSelfTerminating);
+
+        // four encodings on two lines, chunked is not last, so not self terminating
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "gzip, chunked");
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "deflate, gzip");
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(false, isResponseSelfTerminating);
+
+        // three encodings on two lines, chunked is last, so self terminating
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "gzip");
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "deflate,chunked");
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        // #3: 3.If a Content-Length header field (section 14.13) is present, its decimal value in OCTETs represents both the entity-length and the transfer-length.
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.headers().add(HttpHeaders.Names.CONTENT_LENGTH, "15");
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        // continuing #3: If a message is received with both a Transfer-Encoding header field and a Content-Length header field, the latter MUST be ignored.
+
+        // chunked is last Transfer-Encoding, so message is self-terminating
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "gzip, chunked");
+        httpResponse.headers().add(HttpHeaders.Names.CONTENT_LENGTH, "15");
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        // chunked is not last Transfer-Encoding, so message is not self-terminating, since Content-Length is ignored
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "gzip");
+        httpResponse.headers().add(HttpHeaders.Names.CONTENT_LENGTH, "15");
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(false, isResponseSelfTerminating);
+
+        // without any of the above conditions, the message should not be self-terminating
+        // (multipart/byteranges is ignored, see note in method javadoc)
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(false, isResponseSelfTerminating);
+
     }
 }


### PR DESCRIPTION
This PR should address the issues discussed in #203. When an HTTP response is received that has no message-length indicator other than the server closing the connection, LittleProxy will now add a "Transfer-Encoding: chunked" header, which causes netty to automatically generate the proper chunked encoding. LittleProxy will also avoid closing connections to the client, even when all servers disconnect, so the client can re-use the connection for future requests.