### PR TITLE
Enabling filter aggregation for HTTPS responses

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -778,13 +778,11 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 8192 * 2));
         pipeline.addLast("responseReadMonitor", responseReadMonitor);
 
-        if (!ProxyUtils.isCONNECT(httpRequest)) {
-            // Enable aggregation for filtering if necessary
-            int numberOfBytesToBuffer = proxyServer.getFiltersSource()
-                    .getMaximumResponseBufferSizeInBytes();
-            if (numberOfBytesToBuffer > 0) {
-                aggregateContentForFiltering(pipeline, numberOfBytesToBuffer);
-            }
+        // Enable aggregation for filtering if necessary
+        int numberOfBytesToBuffer = proxyServer.getFiltersSource()
+                .getMaximumResponseBufferSizeInBytes();
+        if (numberOfBytesToBuffer > 0) {
+            aggregateContentForFiltering(pipeline, numberOfBytesToBuffer);
         }
 
         pipeline.addLast("bytesWrittenMonitor", bytesWrittenMonitor);


### PR DESCRIPTION
This simple change aligns the ProxyToServerConnection filter behavior with ClientToProxyConnection. I'm not sure why filter aggregation was disabled for responses over HTTPS, but this should correct that issue.