### PR TITLE
Avoid client disconnection on 502, 504, and other short-circuit responses

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpFilters.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFilters.java
@@ -70,24 +70,36 @@ import java.net.InetSocketAddress;
  */
 public interface HttpFilters {
     /**
-     * Filters requests on their way from the client to the proxy.
+     * Filters requests on their way from the client to the proxy. To interrupt processing of this request and return a
+     * response to the client immediately, return an HttpResponse here. Otherwise, return null to continue processing as
+     * usual.
+     * <p/>
+     * <b>Important:</b> When returning a response, you must include a mechanism to allow the client to determine the length
+     * of the message (see RFC 7230, section 3.3.3: https://tools.ietf.org/html/rfc7230#section-3.3.3 ). For messages that
+     * may contain a body, you may do this by setting the Transfer-Encoding to chunked, setting an appropriate
+     * Content-Length, or by adding a "Connection: close" header to the response (which will instruct LittleProxy to close
+     * the connection). If the short-circuit response contains body content, it is recommended that you return a
+     * FullHttpResponse.
      * 
-     * @param httpObject
-     *            Client to Proxy HttpRequest (and HttpContent, if chunked)
-     * @return if you want to interrupted processing and return a response to
-     *         the client, return it here, otherwise return null to continue
-     *         processing as usual
+     * @param httpObject Client to Proxy HttpRequest (and HttpContent, if chunked)
+     * @return a short-circuit response, or null to continue processing as usual
      */
     HttpResponse clientToProxyRequest(HttpObject httpObject);
 
     /**
-     * Filters requests on their way from the proxy to the server.
+     * Filters requests on their way from the proxy to the server. To interrupt processing of this request and return a
+     * response to the client immediately, return an HttpResponse here. Otherwise, return null to continue processing as
+     * usual.
+     * <p/>
+     * <b>Important:</b> When returning a response, you must include a mechanism to allow the client to determine the length
+     * of the message (see RFC 7230, section 3.3.3: https://tools.ietf.org/html/rfc7230#section-3.3.3 ). For messages that
+     * may contain a body, you may do this by setting the Transfer-Encoding to chunked, setting an appropriate
+     * Content-Length, or by adding a "Connection: close" header to the response. (which will instruct LittleProxy to close
+     * the connection). If the short-circuit response contains body content, it is recommended that you return a
+     * FullHttpResponse.
      * 
-     * @param httpObject
-     *            Proxy to Server HttpRequest (and HttpContent, if chunked)
-     * @return if you want to interrupted processing and return a response to
-     *         the client, return it here, otherwise return null to continue
-     *         processing as usual
+     * @param httpObject Proxy to Server HttpRequest (and HttpContent, if chunked)
+     * @return a short-circuit response, or null to continue processing as usual
      */
     HttpResponse proxyToServerRequest(HttpObject httpObject);
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -1123,7 +1123,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.GATEWAY_TIMEOUT, body);
 
-        if (ProxyUtils.isHEAD(httpRequest)) {
+        if (httpRequest != null && ProxyUtils.isHEAD(httpRequest)) {
             // don't allow any body content in response to a HEAD request
             response.content().clear();
         }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -128,6 +128,11 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
     private final GlobalTrafficShapingHandler globalTrafficShapingHandler;
 
+    /**
+     * The current HTTP request that this connection is currently servicing.
+     */
+    private volatile HttpRequest currentRequest;
+
     ClientToProxyConnection(
             final DefaultHttpProxyServer proxyServer,
             SslEngineSource sslEngineSource,
@@ -199,16 +204,24 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private ConnectionState doReadHTTPInitial(HttpRequest httpRequest) {
         // Make a copy of the original request
-        HttpRequest originalRequest = copy(httpRequest);
+        this.currentRequest = copy(httpRequest);
 
         // Set up our filters based on the original request
         currentFilters = proxyServer.getFiltersSource().filterRequest(
-                originalRequest, ctx);
+                currentRequest, ctx);
 
-        // Do the pre filtering
-        if (shortCircuitRespond(currentFilters
-                .clientToProxyRequest(httpRequest))) {
-            return DISCONNECT_REQUESTED;
+        // Send the request through the clientToProxyRequest filter, and respond with the short-circuit response if required
+        HttpResponse clientToProxyFilterResponse = currentFilters.clientToProxyRequest(httpRequest);
+
+        if (clientToProxyFilterResponse != null) {
+            LOG.debug("Responding to client with short-circuit response from filter: {}", clientToProxyFilterResponse);
+
+            boolean keepAlive = respondWithShortCircuitResponse(clientToProxyFilterResponse);
+            if (keepAlive) {
+                return AWAITING_INITIAL;
+            } else {
+                return DISCONNECT_REQUESTED;
+            }
         }
 
         // Identify our server and chained proxy
@@ -218,8 +231,12 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                 httpRequest.getUri());
         if (serverHostAndPort == null || StringUtils.isBlank(serverHostAndPort)) {
             LOG.warn("No host and port found in {}", httpRequest.getUri());
-            writeBadGateway(httpRequest);
-            return DISCONNECT_REQUESTED;
+            boolean keepAlive = writeBadGateway(httpRequest);
+            if (keepAlive) {
+                return AWAITING_INITIAL;
+            } else {
+                return DISCONNECT_REQUESTED;
+            }
         }
 
         LOG.debug("Finding ProxyToServerConnection for: {}", serverHostAndPort);
@@ -250,18 +267,26 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         globalTrafficShapingHandler);
                 if (currentServerConnection == null) {
                     LOG.debug("Unable to create server connection, probably no chained proxies available");
-                    writeBadGateway(httpRequest);
+                    boolean keepAlive = writeBadGateway(httpRequest);
                     resumeReading();
-                    return DISCONNECT_REQUESTED;
+                    if (keepAlive) {
+                        return AWAITING_INITIAL;
+                    } else {
+                        return DISCONNECT_REQUESTED;
+                    }
                 }
                 // Remember the connection for later
                 serverConnectionsByHostAndPort.put(serverHostAndPort,
                         currentServerConnection);
             } catch (UnknownHostException uhe) {
                 LOG.info("Bad Host {}", httpRequest.getUri());
-                writeBadGateway(httpRequest);
+                boolean keepAlive = writeBadGateway(httpRequest);
                 resumeReading();
-                return DISCONNECT_REQUESTED;
+                if (keepAlive) {
+                    return AWAITING_INITIAL;
+                } else {
+                    return DISCONNECT_REQUESTED;
+                }
             }
         } else {
             LOG.debug("Reusing existing server connection: {}",
@@ -270,9 +295,17 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         }
 
         modifyRequestHeadersToReflectProxying(httpRequest);
-        if (shortCircuitRespond(currentFilters
-                .proxyToServerRequest(httpRequest))) {
-            return DISCONNECT_REQUESTED;
+
+        HttpResponse proxyToServerFilterResponse = currentFilters.proxyToServerRequest(httpRequest);
+        if (proxyToServerFilterResponse != null) {
+            LOG.debug("Responding to client with short-circuit response from filter: {}", proxyToServerFilterResponse);
+
+            boolean keepAlive = respondWithShortCircuitResponse(proxyToServerFilterResponse);
+            if (keepAlive) {
+                return AWAITING_INITIAL;
+            } else {
+                return DISCONNECT_REQUESTED;
+            }
         }
 
         LOG.debug("Writing request to ProxyToServerConnection");
@@ -323,6 +356,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     void respond(ProxyToServerConnection serverConnection, HttpFilters filters,
             HttpRequest currentHttpRequest, HttpResponse currentHttpResponse,
             HttpObject httpObject) {
+        // we are sending a response to the client, so we are done handling this request
+        this.currentRequest = null;
+
         httpObject = filters.serverToProxyResponse(httpObject);
         if (httpObject == null) {
             forceDisconnect(serverConnection);
@@ -349,24 +385,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
         closeConnectionsAfterWriteIfNecessary(serverConnection,
                 currentHttpRequest, currentHttpResponse, httpObject);
-    }
-
-    /**
-     * Used for filtering. If a request filter returned a response, we short
-     * circuit processing by sending the response to the client and
-     * disconnecting.
-     * 
-     * @param shortCircuitResponse
-     * @return
-     */
-    private boolean shortCircuitRespond(HttpResponse shortCircuitResponse) {
-        if (shortCircuitResponse != null) {
-            write(shortCircuitResponse);
-            disconnect();
-            return true;
-        } else {
-            return false;
-        }
     }
 
     /***************************************************************************
@@ -412,7 +430,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         || this.lastReadTime > currentServerConnection.lastReadTime;
         if (clientReadMoreRecentlyThanServer) {
             LOG.debug("Server timed out: {}", currentServerConnection);
-            writeGatewayTimeout();
+            writeGatewayTimeout(currentRequest);
         }
         super.timedOut();
     }
@@ -500,18 +518,27 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         serverConnection.getRemoteAddress(),
                         lastStateBeforeFailure,
                         cause);
-                connectionFailedUnrecoverably(initialRequest);
+                connectionFailedUnrecoverably(initialRequest, serverConnection);
                 return false;
             }
         } catch (UnknownHostException uhe) {
-            connectionFailedUnrecoverably(initialRequest);
+            connectionFailedUnrecoverably(initialRequest, serverConnection);
             return false;
         }
     }
 
-    private void connectionFailedUnrecoverably(HttpRequest initialRequest) {
-        writeBadGateway(initialRequest);
-        become(DISCONNECT_REQUESTED);
+    private void connectionFailedUnrecoverably(HttpRequest initialRequest, ProxyToServerConnection serverConnection) {
+        // the connection to the server failed, so disconnect the server and remove the ProxyToServerConnection from the
+        // map of open server connections
+        serverConnection.disconnect();
+        this.serverConnectionsByHostAndPort.remove(serverConnection.getServerHostAndPort());
+
+        boolean keepAlive = writeBadGateway(initialRequest);
+        if (keepAlive) {
+            become(AWAITING_INITIAL);
+        } else {
+            become(DISCONNECT_REQUESTED);
+        }
     }
 
     private void resumeReadingIfNecessary() {
@@ -731,6 +758,12 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             // client itself has requested it be closed in the request.
             return true;
         }
+
+        if (!HttpHeaders.isKeepAlive(res)) {
+            LOG.debug("Closing since response is not keep alive:");
+            return true;
+        }
+
         LOG.debug("Not closing client to proxy connection for request: {}", req);
         return false;
     }
@@ -1058,28 +1091,85 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      **************************************************************************/
 
     /**
-     * Tells the client that something went wrong trying to proxy its request.
-     * 
-     * @param request
+     * Tells the client that something went wrong trying to proxy its request. If the Bad Gateway is a response to
+     * an HTTP HEAD request, the response will contain no body, but the Content-Length header will be set to the
+     * value it would have been if this 502 Bad Gateway were in response to a GET.
+     *
+     * @param httpRequest the HttpRequest that is resulting in the Bad Gateway response
+     * @return true if the connection will be kept open, or false if it will be disconnected
      */
-    private void writeBadGateway(HttpRequest request) {
-        String body = "Bad Gateway: " + request.getUri();
-        DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1,
-                HttpResponseStatus.BAD_GATEWAY, body);
-        response.headers().set(HttpHeaders.Names.CONNECTION, "close");
-        write(response);
-        disconnect();
+    private boolean writeBadGateway(HttpRequest httpRequest) {
+        String body = "Bad Gateway: " + httpRequest.getUri();
+        DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_GATEWAY, body);
+
+        if (ProxyUtils.isHEAD(httpRequest)) {
+            // don't allow any body content in response to a HEAD request
+            response.content().clear();
+        }
+
+        return respondWithShortCircuitResponse(response);
     }
 
     /**
-     * Tells the client that the connection to the server timed out.
+     * Tells the client that the connection to the server, or possibly to some intermediary service (such as DNS), timed out.
+     * If the Gateway Timeout is a response to an HTTP HEAD request, the response will contain no body, but the
+     * Content-Length header will be set to the value it would have been if this 504 Gateway Timeout were in response to a GET.
+     *
+     * @param httpRequest the HttpRequest that is resulting in the Gateway Timeout response
+     * @return true if the connection will be kept open, or false if it will be disconnected
      */
-    private void writeGatewayTimeout() {
+    private boolean writeGatewayTimeout(HttpRequest httpRequest) {
         String body = "Gateway Timeout";
         DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.GATEWAY_TIMEOUT, body);
-        response.headers().set(HttpHeaders.Names.CONNECTION, "close");
-        write(response);
+
+        if (ProxyUtils.isHEAD(httpRequest)) {
+            // don't allow any body content in response to a HEAD request
+            response.content().clear();
+        }
+
+        return respondWithShortCircuitResponse(response);
+    }
+
+    /**
+     * Responds to the client with the specified "short-circuit" response. The response will be sent through the
+     * {@link HttpFilters#proxyToClientResponse(HttpObject)} filter method before writing it to the client. The client
+     * will not be disconnected, unless the response includes a "Connection: close" header, or the filter returns
+     * a null HttpResponse (in which case no response will be written to the client and the connection will be
+     * disconnected immediately). If the response is not a Bad Gateway or Gateway Timeout response, the response's headers
+     * will be modified to reflect proxying, including adding a Via header, Date header, etc.
+     *
+     * @param httpResponse the response to return to the client
+     * @return true if the connection will be kept open, or false if it will be disconnected.
+     */
+    private boolean respondWithShortCircuitResponse(HttpResponse httpResponse) {
+        // we are sending a response to the client, so we are done handling this request
+        this.currentRequest = null;
+
+        HttpResponse filteredResponse = (HttpResponse) currentFilters.proxyToClientResponse(httpResponse);
+        if (filteredResponse == null) {
+            disconnect();
+            return false;
+        }
+
+        // if the response is not a Bad Gateway or Gateway Timeout, modify the headers "as if" he short-circuit response were proxied
+        int statusCode = httpResponse.getStatus().code();
+        if (statusCode != HttpResponseStatus.BAD_GATEWAY.code() && statusCode != HttpResponseStatus.GATEWAY_TIMEOUT.code()) {
+            modifyResponseHeadersToReflectProxying(httpResponse);
+        }
+
+        write(httpResponse);
+
+        if (ProxyUtils.isLastChunk(httpResponse)) {
+            writeEmptyBuffer();
+        }
+
+        if (!HttpHeaders.isKeepAlive(httpResponse)) {
+            disconnect();
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -320,6 +320,16 @@ public class ProxyUtils {
                         .getMethod());
     }
 
+    /**
+     * Returns true if the specified HttpRequest is a HEAD request.
+     *
+     * @param httpRequest http request
+     * @return true if request is a HEAD, otherwise false
+     */
+    public static boolean isHEAD(HttpRequest httpRequest) {
+        return HttpMethod.HEAD.equals(httpRequest.getMethod());
+    }
+
     private static boolean checkTrueOrFalse(final String val,
             final String str1, final String str2) {
         final String str = val.trim();

--- a/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
+++ b/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
@@ -1,0 +1,349 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.SocketClientUtil;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.matchers.Times;
+import org.mockserver.model.ConnectionOptions;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+/**
+ * This class tests the proxy's keep alive/connection closure behavior.
+ */
+public class KeepAliveTest {
+    private HttpProxyServer proxyServer;
+
+    private ClientAndServer mockServer;
+    private int mockServerPort;
+
+    private Socket socket;
+
+    @Before
+    public void setUp() throws Exception {
+        mockServer = new ClientAndServer(0);
+        mockServerPort = mockServer.getPort();
+        socket = null;
+        proxyServer = null;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            if (proxyServer != null) {
+                proxyServer.abort();
+            }
+        } finally {
+            try {
+                if (mockServer != null) {
+                    mockServer.stop();
+                }
+            } finally {
+                if (socket != null) {
+                    socket.close();
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests that the proxy does not close the connection after a successful HTTP 1.1 GET request and response.
+     */
+    @Test
+    public void testHttp11DoesNotCloseConnectionByDefault() throws IOException, InterruptedException {
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/success"),
+                Times.exactly(2))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withBody("success"));
+
+        this.proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
+        this.socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        // construct the basic request: METHOD + URI + HTTP version + CRLF (to indicate the end of the request)
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+                + "\r\n";
+
+        // send the same request twice over the same connection
+        for (int i = 1; i <= 2; i++) {
+            SocketClientUtil.writeStringToSocket(successfulGet, socket);
+
+            // wait a bit to allow the proxy server to respond
+            Thread.sleep(750);
+
+            String response = SocketClientUtil.readStringFromSocket(socket);
+
+            assertThat("Expected to receive an HTTP 200 from the server (iteration: " + i + ")", response, startsWith("HTTP/1.1 200 OK"));
+            assertThat("Unexpected message body (iteration: " + i + ")", response, endsWith("success"));
+        }
+
+        assertTrue("Expected connection to proxy server to be open and readable", SocketClientUtil.isSocketReadyToRead(socket));
+        assertTrue("Expected connection to proxy server to be open and writable", SocketClientUtil.isSocketReadyToWrite(socket));
+    }
+
+    /**
+     * Tests that the proxy keeps the connection to the client open after a server disconnect, even when the server is using
+     * connection closure to indicate the end of a message.
+     */
+    @Test
+    public void testProxyKeepsClientConnectionOpenAfterServerDisconnect() throws IOException, InterruptedException {
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/success"),
+                Times.exactly(2))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withBody("success")
+                        .withConnectionOptions(new ConnectionOptions()
+                                .withKeepAliveOverride(false)
+                                .withSuppressContentLengthHeader(true)
+                                .withCloseSocket(true)));
+
+        this.proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
+        this.socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        // construct the basic request: METHOD + URI + HTTP version + CRLF (to indicate the end of the request)
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+                + "\r\n";
+
+        // send the same request twice over the same connection
+        for (int i = 1; i <= 2; i++) {
+            SocketClientUtil.writeStringToSocket(successfulGet, socket);
+
+            // wait a bit to allow the proxy server to respond
+            Thread.sleep(750);
+
+            String response = SocketClientUtil.readStringFromSocket(socket);
+
+            assertThat("Expected to receive an HTTP 200 from the server (iteration: " + i + ")", response, startsWith("HTTP/1.1 200 OK"));
+            // the proxy will set the Transfer-Encoding to chunked since the server is using connection closure to indicate the end of the message
+            assertThat("Expected proxy to set Transfer-Encoding to chunked", response, containsString("Transfer-Encoding: chunked"));
+            // the Transfer-Encoding is chunked, so the body text will be followed by a 0 and 2 CRLFs
+            assertThat("Unexpected message body (iteration: " + i + ")", response, containsString("success"));
+        }
+
+        assertTrue("Expected connection to proxy server to be open and readable", SocketClientUtil.isSocketReadyToRead(socket));
+        assertTrue("Expected connection to proxy server to be open and writable", SocketClientUtil.isSocketReadyToWrite(socket));
+    }
+
+    /**
+     * Tests that the proxy does not close the connection after a 502 Bad Gateway response.
+     */
+    @Test
+    public void testBadGatewayDoesNotCloseConnection() throws IOException, InterruptedException {
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/success"),
+                Times.exactly(1))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withBody("success"));
+
+        this.proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
+
+        socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        String badGatewayGet = "GET http://localhost:0/success HTTP/1.1\n"
+                + "\r\n";
+
+        // send the same request twice over the same connection
+        for (int i = 1; i <= 2; i++) {
+            SocketClientUtil.writeStringToSocket(badGatewayGet, socket);
+
+            // wait a bit to allow the proxy server to respond
+            Thread.sleep(1500);
+
+            String response = SocketClientUtil.readStringFromSocket(socket);
+
+            assertThat("Expected to receive an HTTP 200 from the server (iteration: " + i + ")", response, startsWith("HTTP/1.1 502 Bad Gateway"));
+        }
+
+        assertTrue("Expected connection to proxy server to be open and readable", SocketClientUtil.isSocketReadyToRead(socket));
+        assertTrue("Expected connection to proxy server to be open and writable", SocketClientUtil.isSocketReadyToWrite(socket));
+    }
+
+    /**
+     * Tests that the proxy does not close the connection after a 504 Gateway Timeout response.
+     */
+    @Test
+    public void testGatewayTimeoutDoesNotCloseConnection() throws IOException, InterruptedException {
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/success"),
+                Times.exactly(2))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withDelay(TimeUnit.SECONDS, 10)
+                        .withBody("success"));
+
+        this.proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withIdleConnectionTimeout(3)
+                .withPort(0)
+                .start();
+
+        socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+                + "\r\n";
+
+        // send the same request twice over the same connection
+        for (int i = 1; i <= 2; i++) {
+            SocketClientUtil.writeStringToSocket(successfulGet, socket);
+
+            // wait a bit to allow the proxy server to respond
+            Thread.sleep(3500);
+
+            String response = SocketClientUtil.readStringFromSocket(socket);
+
+            assertThat("Expected to receive an HTTP 200 from the server (iteration: " + i + ")", response, startsWith("HTTP/1.1 504 Gateway Timeout"));
+        }
+
+        assertTrue("Expected connection to proxy server to be open and readable", SocketClientUtil.isSocketReadyToRead(socket));
+        assertTrue("Expected connection to proxy server to be open and writable", SocketClientUtil.isSocketReadyToWrite(socket));
+    }
+
+    /**
+     * Tests that the proxy does not close the connection by default after a short-circuit response.
+     */
+    @Test
+    public void testShortCircuitResponseDoesNotCloseConnectionByDefault() throws IOException, InterruptedException {
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/success"),
+                Times.exactly(1))
+                .respond(response()
+                        .withStatusCode(500)
+                        .withBody("this response should never be sent"));
+
+        HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter() {
+            @Override
+            public HttpFilters filterRequest(HttpRequest originalRequest) {
+                return new HttpFiltersAdapter(originalRequest) {
+                    @Override
+                    public HttpResponse clientToProxyRequest(HttpObject httpObject) {
+                        if (httpObject instanceof HttpRequest) {
+                            HttpResponse shortCircuitResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+                            HttpHeaders.setContentLength(shortCircuitResponse, 0);
+                            return shortCircuitResponse;
+                        } else {
+                            return null;
+                        }
+                    }
+                };
+            }
+        };
+
+        this.proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .withFiltersSource(filtersSource)
+                .start();
+
+        socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+                + "\r\n";
+
+        // send the same request twice over the same connection
+        for (int i = 1; i <= 2; i++) {
+            SocketClientUtil.writeStringToSocket(successfulGet, socket);
+
+            // wait a bit to allow the proxy server to respond
+            Thread.sleep(750);
+
+            String response = SocketClientUtil.readStringFromSocket(socket);
+
+            assertThat("Expected to receive an HTTP 200 from the server (iteration: " + i + ")", response, startsWith("HTTP/1.1 200 OK"));
+        }
+
+        assertTrue("Expected connection to proxy server to be open and readable", SocketClientUtil.isSocketReadyToRead(socket));
+        assertTrue("Expected connection to proxy server to be open and writable", SocketClientUtil.isSocketReadyToWrite(socket));
+    }
+
+    /**
+     * Tests that the proxy will close the connection after a short circuit response if the short circuit response
+     * contains a Connection: close header.
+     */
+    @Test
+    public void testShortCircuitResponseCanCloseConnection() throws IOException, InterruptedException {
+        mockServer.when(request()
+                        .withMethod("GET")
+                        .withPath("/success"),
+                Times.exactly(1))
+                .respond(response()
+                        .withStatusCode(500)
+                        .withBody("this response should never be sent"));
+
+        HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter() {
+            @Override
+            public HttpFilters filterRequest(HttpRequest originalRequest) {
+                return new HttpFiltersAdapter(originalRequest) {
+                    @Override
+                    public HttpResponse clientToProxyRequest(HttpObject httpObject) {
+                        if (httpObject instanceof HttpRequest) {
+                            HttpResponse shortCircuitResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+                            HttpHeaders.setContentLength(shortCircuitResponse, 0);
+                            HttpHeaders.setKeepAlive(shortCircuitResponse, false);
+                            return shortCircuitResponse;
+                        } else {
+                            return null;
+                        }
+                    }
+                };
+            }
+        };
+
+        this.proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .withFiltersSource(filtersSource)
+                .start();
+
+        socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+                + "\r\n";
+
+        // only send this request once, since we expect the short circuit response to close the connection
+        SocketClientUtil.writeStringToSocket(successfulGet, socket);
+
+        // wait a bit to allow the proxy server to respond
+        Thread.sleep(750);
+
+        String response = SocketClientUtil.readStringFromSocket(socket);
+
+        assertThat("Expected to receive an HTTP 200 from the server", response, startsWith("HTTP/1.1 200 OK"));
+
+        assertFalse("Expected connection to proxy server to be closed", SocketClientUtil.isSocketReadyToRead(socket));
+        assertFalse("Expected connection to proxy server to be closed", SocketClientUtil.isSocketReadyToWrite(socket));
+    }
+}
+

--- a/src/test/java/org/littleshoot/proxy/test/SocketClientUtil.java
+++ b/src/test/java/org/littleshoot/proxy/test/SocketClientUtil.java
@@ -1,0 +1,113 @@
+package org.littleshoot.proxy.test;
+
+import org.littleshoot.proxy.HttpProxyServer;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.nio.charset.Charset;
+
+/**
+ * Utilities for interacting with the proxy server using sockets.
+ */
+public class SocketClientUtil {
+    /**
+     * Writes and flushes the UTF-8 encoded contents of a String to a socket.
+     *
+     * @param string string to write
+     * @param socket socket to write to
+     * @throws IOException
+     */
+    public static void writeStringToSocket(String string, Socket socket) throws IOException {
+        OutputStream out = socket.getOutputStream();
+        out.write(string.getBytes(Charset.forName("UTF-8")));
+        out.flush();
+    }
+
+    /**
+     * Reads all available data from the socket and returns a String containing that content, interpreted in the
+     * UTF-8 charset.
+     *
+     * @param socket socket to read UTF-8 bytes from
+     * @return String containing the contents of whatever was read from the socket
+     * @throws EOFException if the socket has been closed
+     */
+    public static String readStringFromSocket(Socket socket) throws IOException {
+        InputStream in = socket.getInputStream();
+        byte[] bytes = new byte[10000];
+        int bytesRead = in.read(bytes);
+        if (bytesRead == -1) {
+            throw new EOFException("Unable to read from socket. The socket is closed.");
+        }
+
+        String read = new String(bytes, 0, bytesRead, Charset.forName("UTF-8"));
+
+        return read;
+    }
+
+    /**
+     * Determines if the socket can be written to. This method tests the writability of the socket by writing to the socket,
+     * so it should only be used immediately before closing the socket.
+     *
+     * @param socket socket to test
+     * @return true if the socket is open and can be written to, otherwise false
+     * @throws IOException
+     */
+    public static boolean isSocketReadyToWrite(Socket socket) throws IOException {
+        OutputStream out = socket.getOutputStream();
+        try {
+            out.write(0);
+            out.flush();
+            out.write(0);
+            out.flush();
+        } catch (SocketException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines if the socket can be read from. This method tests the readability of the socket by attempting to read
+     * a byte from the socket. If successful, the byte will be lost, so this method should only be called immediately
+     * before closing the socket.
+     *
+     * @param socket socket to test
+     * @return true if the socket is open and can be read from, otherwise false
+     * @throws IOException
+     */
+    public static boolean isSocketReadyToRead(Socket socket) throws IOException {
+        InputStream in = socket.getInputStream();
+        try {
+            int readByte = in.read();
+
+            // we just lost that byte but it doesn't really matter for testing purposes
+            return readByte != -1;
+        } catch (SocketException e) {
+            // the socket couldn't be read, perhaps because the connection was reset or some other error. it cannot be read.
+          return false;
+        } catch (SocketTimeoutException e) {
+            // the read timed out, which means the socket is still connected but there's no data on it
+            return true;
+        }
+    }
+
+    /**
+     * Opens a socket to the specified proxy server with a 3s timeout. The socket should be closed after it has been used.
+     *
+     * @param proxyServer proxy server to open the socket to
+     * @return the new socket
+     * @throws IOException
+     */
+    public static Socket getSocketToProxyServer(HttpProxyServer proxyServer) throws IOException {
+        Socket socket = new Socket();
+        socket.connect(new InetSocketAddress("localhost", proxyServer.getListenAddress().getPort()), 1000);
+        socket.setSoTimeout(3000);
+        return socket;
+    }
+}


### PR DESCRIPTION
This is similar in spirit to #204, but for proxy-generated short circuit responses such as Bad Gateway and Gateway Timeout messages. Previously LittleProxy was always closing the connection to the client for any 502 or 504 response. Besides being inefficient, this also caused this scenario envisioned in the HTTP specification [(RFC 7230, section 6.6)](https://tools.ietf.org/html/rfc7230#section-6.6) to occur:
> If a server performs an immediate close of a TCP connection, there is
   a significant risk that the client will not be able to read the last
   HTTP response.  If the server receives additional data from the
   client on a fully closed connection, such as another request that was
   sent by the client before receiving the server's response, the
   server's TCP stack will send a reset packet to the client;
   unfortunately, the reset packet might erase the client's
   unacknowledged input buffers before they can be read and interpreted
   by the client's HTTP parser.

I was seeing frequent but intermittent unit test failures for the Bad Gateway chained proxy tests in my travis-ci builds of LittleProxy, where the tests would hang and eventually return a 504 Gateway Timeout instead of a 502. I believe this was the culprit. After applying this PR, I have not been able to reproduce the issue.

This will make the proxy a bit more efficient for clients, and also bring us one step closer to enabling unit tests in the travis-ci builds.

Additionally, this change allows the filters to return short-circuit responses without automatically closing the connection. (If users still want the short-circuit responses to close the connection, they can still add a Connection: close header to the response.)