### PR TITLE
Fixed parsing issue with ipv6 address literals

### DIFF
--- a/src/test/java/org/littleshoot/proxy/impl/ProxyToServerConnectionUtilsTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ProxyToServerConnectionUtilsTest.java
@@ -1,0 +1,48 @@
+package org.littleshoot.proxy.impl;
+
+import org.junit.Test;
+import org.littleshoot.proxy.HostResolver;
+
+import java.net.UnknownHostException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for static helper methods in {@link ProxyToServerConnection}.
+ */
+public class ProxyToServerConnectionUtilsTest {
+    @Test
+    public void testParseAddresses() throws UnknownHostException {
+        // mock out the proxy server and resolver; this test only verifies the addresses parse correctly
+        DefaultHttpProxyServer mockProxyServer = mock(DefaultHttpProxyServer.class);
+        HostResolver mockHostResolver = mock(HostResolver.class);
+
+        when(mockProxyServer.getServerResolver()).thenReturn(mockHostResolver);
+
+        ProxyToServerConnection.addressFor("192.168.1.1", mockProxyServer);
+        verify(mockHostResolver).resolve("192.168.1.1", 80);
+
+        ProxyToServerConnection.addressFor("192.168.1.1:72", mockProxyServer);
+        verify(mockHostResolver).resolve("192.168.1.1", 72);
+
+        ProxyToServerConnection.addressFor("www.google.com", mockProxyServer);
+        verify(mockHostResolver).resolve("www.google.com", 80);
+
+        ProxyToServerConnection.addressFor("www.google.com:19650", mockProxyServer);
+        verify(mockHostResolver).resolve("www.google.com", 19650);
+
+        ProxyToServerConnection.addressFor("[::1]", mockProxyServer);
+        verify(mockHostResolver).resolve("::1", 80);
+
+        ProxyToServerConnection.addressFor("[::1]:56500", mockProxyServer);
+        verify(mockHostResolver).resolve("::1", 56500);
+
+        ProxyToServerConnection.addressFor("[a:b:c:d::1]", mockProxyServer);
+        verify(mockHostResolver).resolve("a:b:c:d::1", 80);
+
+        ProxyToServerConnection.addressFor("[a:b:c:d::1]:8650", mockProxyServer);
+        verify(mockHostResolver).resolve("a:b:c:d::1", 8650);
+    }
+}


### PR DESCRIPTION
This is a fix for the rather old issue #30. This replaces the custom address-parsing logic with Guava's HostAndPort.