### PR TITLE
Add DNS failure and response timeout filter methods

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpFilters.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFilters.java
@@ -112,6 +112,15 @@ public interface HttpFilters {
     HttpObject serverToProxyResponse(HttpObject httpObject);
 
     /**
+     * Informs filter that a timeout occurred before the server response was received by the client. The timeout may have
+     * occurred while the client was sending the request, waiting for a response, or after the client started receiving
+     * a response (i.e. if the response from the server "stalls").
+     *
+     * See {@link HttpProxyServerBootstrap#withIdleConnectionTimeout(int)} for information on setting the timeout.
+     */
+    void serverToProxyResponseTimedOut();
+
+    /**
      * Informs filter that server to proxy response is being received.
      */
     void serverToProxyResponseReceiving();

--- a/src/main/java/org/littleshoot/proxy/HttpFilters.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFilters.java
@@ -148,6 +148,13 @@ public interface HttpFilters {
             String resolvingServerHostAndPort);
 
     /**
+     * Informs filter that proxy to server DNS resolution failed for the specified host and port.
+     *
+     * @param hostAndPort hostname and port the proxy failed to resolve
+     */
+    void proxyToServerResolutionFailed(String hostAndPort);
+
+    /**
      * Informs filter that proxy to server DNS resolution has happened.
      * 
      * @param serverHostAndPort

--- a/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
@@ -71,6 +71,10 @@ public class HttpFiltersAdapter implements HttpFilters {
     }
 
     @Override
+    public void proxyToServerResolutionFailed(String hostAndPort) {
+    }
+
+    @Override
     public void proxyToServerResolutionSucceeded(String serverHostAndPort,
             InetSocketAddress resolvedRemoteAddress) {
     }

--- a/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
@@ -48,6 +48,10 @@ public class HttpFiltersAdapter implements HttpFilters {
     }
 
     @Override
+    public void serverToProxyResponseTimedOut() {
+    }
+
+    @Override
     public void serverToProxyResponseReceiving() {
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -523,6 +523,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         serverConnection.getRemoteAddress(),
                         lastStateBeforeFailure,
                         cause);
+                currentFilters.proxyToServerConnectionFailed();
                 connectionFailedUnrecoverably(initialRequest);
                 return false;
             }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -435,6 +435,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         || this.lastReadTime > currentServerConnection.lastReadTime;
         if (clientReadMoreRecentlyThanServer) {
             LOG.debug("Server timed out: {}", currentServerConnection);
+            currentFilters.serverToProxyResponseTimedOut();
             writeGatewayTimeout();
         }
         super.timedOut();

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -523,6 +523,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         serverConnection.getRemoteAddress(),
                         lastStateBeforeFailure,
                         cause);
+                // all attempts to connect using all available upstream proxies and direct connections have failed, so inform
+                // the filters that the connection failed
                 currentFilters.proxyToServerConnectionFailed();
                 connectionFailedUnrecoverably(initialRequest);
                 return false;

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -524,9 +524,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                         serverConnection.getRemoteAddress(),
                         lastStateBeforeFailure,
                         cause);
-                // all attempts to connect using all available upstream proxies and direct connections have failed, so inform
-                // the filters that the connection failed
-                currentFilters.proxyToServerConnectionFailed();
                 connectionFailedUnrecoverably(initialRequest);
                 return false;
             }

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
@@ -48,7 +48,7 @@ enum ConnectionState {
      */
     DISCONNECTED();
 
-    private boolean partOfConnectionFlow;
+    private final boolean partOfConnectionFlow;
 
     ConnectionState(boolean partOfConnectionFlow) {
         this.partOfConnectionFlow = partOfConnectionFlow;
@@ -63,10 +63,19 @@ enum ConnectionState {
      * {@link ConnectionFlow}. This is useful to distinguish so that we know
      * whether or not we're in the process of establishing a connection.
      * 
-     * @return
+     * @return true if part of connection flow, otherwise false
      */
     public boolean isPartOfConnectionFlow() {
         return partOfConnectionFlow;
     }
 
+    /**
+     * Indicates whether this ConnectionState is no longer waiting for messages and is either in the process of disconnecting
+     * or is already disconnected.
+     *
+     * @return true if the connection state is {@link #DISCONNECT_REQUESTED} or {@link #DISCONNECTED}, otherwise false
+     */
+    public boolean isDisconnectingOrDisconnected() {
+        return this == DISCONNECT_REQUESTED || this == DISCONNECTED;
+    }
 }

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -463,6 +463,7 @@ public class HttpFilterTest {
         assertTrue("Expected filter method to be called", filter.isClientToProxyRequestInvoked());
         assertTrue("Expected filter method to be called", filter.isProxyToServerConnectionQueuedInvoked());
         assertTrue("Expected filter method to be called", filter.isProxyToServerResolutionStartedInvoked());
+        assertTrue("Expected filter method to be called", filter.isProxyToClientResponseInvoked());
 
         assertFalse("Expected filter method to not be called", filter.isProxyToServerConnectionStartedInvoked());
         assertFalse("Expected filter method to not be called", filter.isProxyToServerRequestInvoked());
@@ -474,7 +475,6 @@ public class HttpFilterTest {
         assertFalse("Expected filter method to not be called", filter.isServerToProxyResponseReceivingInvoked());
         assertFalse("Expected filter method to not be called", filter.isServerToProxyResponseInvoked());
         assertFalse("Expected filter method to not be called", filter.isServerToProxyResponseReceivedInvoked());
-        assertFalse("Expected filter method to not be called", filter.isProxyToClientResponseInvoked());
         assertFalse("Expected filter method to not be called", filter.isServerToProxyResponseTimedOutInvoked());
     }
 
@@ -506,6 +506,7 @@ public class HttpFilterTest {
         assertTrue("Expected filter method to be called", filter.isProxyToServerConnectionStartedInvoked());
         assertTrue("Expected filter method to be called", filter.isProxyToServerResolutionStartedInvoked());
         assertTrue("Expected filter method to be called", filter.isProxyToServerResolutionSucceededInvoked());
+        assertTrue("Expected filter method to be called", filter.isProxyToClientResponseInvoked());
 
         assertFalse("Expected filter method to not be called", filter.isProxyToServerRequestSendingInvoked());
         assertFalse("Expected filter method to not be called", filter.isProxyToServerRequestSentInvoked());
@@ -514,7 +515,6 @@ public class HttpFilterTest {
         assertFalse("Expected filter method to not be called", filter.isServerToProxyResponseReceivingInvoked());
         assertFalse("Expected filter method to not be called", filter.isServerToProxyResponseInvoked());
         assertFalse("Expected filter method to not be called", filter.isServerToProxyResponseReceivedInvoked());
-        assertFalse("Expected filter method to not be called", filter.isProxyToClientResponseInvoked());
         assertFalse("Expected filter method to not be called", filter.isServerToProxyResponseTimedOutInvoked());
     }
 
@@ -564,11 +564,11 @@ public class HttpFilterTest {
         assertTrue("Expected filter method to be called", filter.isProxyToServerRequestSendingInvoked());
         assertTrue("Expected filter method to be called", filter.isProxyToServerRequestSentInvoked());
         assertTrue("Expected filter method to be called", filter.isProxyToServerConnectionSucceededInvoked());
+        assertTrue("Expected filter method to be called", filter.isProxyToClientResponseInvoked());
 
         assertFalse("Expected filter method to not be called", filter.isProxyToServerResolutionFailedInvoked());
         assertFalse("Expected filter method to not be called", filter.isProxyToServerConnectionFailedInvoked());
         assertFalse("Expected filter method to not be called", filter.isProxyToServerConnectionSSLHandshakeStartedInvoked());
-        assertFalse("Expected filter method to not be called", filter.isProxyToClientResponseInvoked());
     }
 
     @Test

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -75,7 +75,7 @@ public class HttpFilterTest {
         } finally {
             try {
                 if (proxyServer != null) {
-                    proxyServer.stop();
+                    proxyServer.abort();
                 }
             } finally {
                 if (mockServer != null) {


### PR DESCRIPTION
This PR adds two new lifecycle filters for error scenarios:

1. `proxyToServerResolutionFailed(String hostAndPort)` -- called when DNS resolution fails
2. `serverToProxyResponseTimedOut()` -- called when the proxy-to-server connection goes idle before the response is received

We already have an existing filter method for connection failure: `proxyToServerConnectionFailed()`. This PR also fixes a defect with that error condition where the `proxyToServerRequest(...)` method would be called even when the connection failed because the proxy was writing an EmptyLastHttpContent after a connection failure. (The unit test in `HttpFilterTest#testConnectionFailedCalledAfterConnectionFailure()` demonstrates the failure when executed against the current code in master.)