### PR TITLE
Make ChannelHandlerContext of server connection available to filters

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpFilters.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFilters.java
@@ -1,6 +1,8 @@
 package org.littleshoot.proxy;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
+
 import org.littleshoot.proxy.impl.ProxyUtils;
 
 import java.net.InetSocketAddress;
@@ -175,7 +177,9 @@ public interface HttpFilters {
 
     /**
      * Informs filter that proxy to server connection has succeeded.
+     * 
+     * @param toServerCtx 
      */
-    void proxyToServerConnectionSucceeded();
+    void proxyToServerConnectionSucceeded(ChannelHandlerContext toServerCtx);
 
 }

--- a/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
@@ -12,12 +12,12 @@ import java.net.InetSocketAddress;
  */
 public class HttpFiltersAdapter implements HttpFilters {
     protected final HttpRequest originalRequest;
-    protected final ChannelHandlerContext ctx;
+    protected final ChannelHandlerContext clientCtx;
 
     public HttpFiltersAdapter(HttpRequest originalRequest,
-            ChannelHandlerContext ctx) {
+            ChannelHandlerContext clientCtx) {
         this.originalRequest = originalRequest;
-        this.ctx = ctx;
+        this.clientCtx = clientCtx;
     }
 
     public HttpFiltersAdapter(HttpRequest originalRequest) {
@@ -88,6 +88,6 @@ public class HttpFiltersAdapter implements HttpFilters {
     }
 
     @Override
-    public void proxyToServerConnectionSucceeded() {
+    public void proxyToServerConnectionSucceeded(ChannelHandlerContext serverCtx) {
     }
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -347,13 +347,13 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             if (newState == HANDSHAKING) {
                 currentFilters.proxyToServerConnectionSSLHandshakeStarted();
             } else if (newState == AWAITING_INITIAL) {
-                currentFilters.proxyToServerConnectionSucceeded();
+                currentFilters.proxyToServerConnectionSucceeded(serverConnection.ctx);
             } else if (newState == DISCONNECTED) {
                 currentFilters.proxyToServerConnectionFailed();
             }
         } else if (getCurrentState() == HANDSHAKING
                 && newState == AWAITING_INITIAL) {
-            currentFilters.proxyToServerConnectionSucceeded();
+            currentFilters.proxyToServerConnectionSucceeded(serverConnection.ctx);
         } else if (getCurrentState() == AWAITING_CHUNK
                 && newState != AWAITING_CHUNK) {
             currentFilters.serverToProxyResponseReceived();

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -1,5 +1,6 @@
 package org.littleshoot.proxy;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpObject;
@@ -8,6 +9,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -248,7 +250,7 @@ public class HttpFilterTest {
                     }
 
                     @Override
-                    public void proxyToServerConnectionSucceeded() {
+                    public void proxyToServerConnectionSucceeded(ChannelHandlerContext serverCtx) {
                         proxyToServerConnectionSucceededNanos.set(requestCount.get(), now());
                     }
 


### PR DESCRIPTION
With #122 context of the client connection only was made available to filters. It makes it possible to access the pipeline change codecs and decoders, if needed. This PR provides the server context on connection succeded too.

Please, see this forum diskussion for the current motivation: https://groups.google.com/forum/#!topic/littleproxy/a159pd1wHoc