### PR TITLE
Response 400 for direct proxy requests to avoid an endless loop.

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -225,7 +225,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         // Requesting the proxy directly must be answered elsewhere it causes an
         // endless loop
         //
-        if (clientToProxyFilterResponse == null && isProxyRequested()) {
+        if (clientToProxyFilterResponse == null && isRequestToOriginServer()) {
             clientToProxyFilterResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                     HttpResponseStatus.BAD_REQUEST);
         }
@@ -338,7 +338,16 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         }
     }
 
-    private boolean isProxyRequested() {
+    /**
+     * RFC 7230 section 5.7 "Message Forwarding" states:
+     * 
+     * An intermediary MUST NOT forward a message to itself unless it is
+     * protected from an infinite request loop. In general, an intermediary
+     * ought to recognize its own server names, including any aliases, local
+     * variations, or literal IP addresses, and respond to such requests
+     * directly.
+     */
+    private boolean isRequestToOriginServer() {
         // HTTPS requests have uri without http scheme too
         if (currentRequest.getMethod() == HttpMethod.CONNECT || sslEngine != null) {
             return false;

--- a/src/test/java/org/littleshoot/proxy/AbstractProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/AbstractProxyTest.java
@@ -162,7 +162,7 @@ public abstract class AbstractProxyTest {
             throws Exception {
         String username = getUsername();
         String password = getPassword();
-        final DefaultHttpClient httpClient = buildHttpClient();
+        final DefaultHttpClient httpClient = TestUtils.buildHttpClient();
         try {
             if (isProxied) {
                 final HttpHost proxy = new HttpHost("127.0.0.1",
@@ -202,7 +202,7 @@ public abstract class AbstractProxyTest {
             throws Exception {
         String username = getUsername();
         String password = getPassword();
-        DefaultHttpClient httpClient = buildHttpClient();
+        DefaultHttpClient httpClient = TestUtils.buildHttpClient();
         try {
             if (isProxied) {
                 HttpHost proxy = new HttpHost("127.0.0.1", proxyServer.getListenAddress().getPort());
@@ -249,32 +249,6 @@ public abstract class AbstractProxyTest {
         } finally {
             httpClient.getConnectionManager().shutdown();
         }
-    }
-
-    private DefaultHttpClient buildHttpClient() throws Exception {
-        DefaultHttpClient httpClient = new DefaultHttpClient();
-        SSLSocketFactory sf = new SSLSocketFactory(
-                new TrustSelfSignedStrategy(), new X509HostnameVerifier() {
-                    public boolean verify(String arg0, SSLSession arg1) {
-                        return true;
-                    }
-
-                    public void verify(String host, String[] cns,
-                            String[] subjectAlts)
-                            throws SSLException {
-                    }
-
-                    public void verify(String host, X509Certificate cert)
-                            throws SSLException {
-                    }
-
-                    public void verify(String host, SSLSocket ssl)
-                            throws IOException {
-                    }
-                });
-        Scheme scheme = new Scheme("https", 443, sf);
-        httpClient.getConnectionManager().getSchemeRegistry().register(scheme);
-        return httpClient;
     }
 
     protected String compareProxiedAndUnproxiedPOST(HttpHost host,

--- a/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
+++ b/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
@@ -1,7 +1,6 @@
 package org.littleshoot.proxy;
 
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
@@ -9,44 +8,49 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
-import java.net.Socket;
+import java.io.IOException;
+import java.security.cert.X509Certificate;
 
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
-import org.littleshoot.proxy.test.SocketClientUtil;
 
 /**
  * This class tests direct requests to the proxy server, which causes endless
  * loops (#205).
  */
 public class DirectRequestTest {
-    private HttpProxyServer proxyServer;
 
-    private Socket socket;
+    private HttpProxyServer proxyServer;
 
     @Before
     public void setUp() throws Exception {
-        socket = null;
         proxyServer = null;
     }
 
     @After
     public void tearDown() throws Exception {
-        try {
-            if (proxyServer != null) {
-                proxyServer.abort();
-            }
-        } finally {
-            if (socket != null) {
-                socket.close();
-            }
+        if (proxyServer != null) {
+            proxyServer.abort();
         }
     }
 
     @Test(timeout = 5000)
-    public void testDirectRequestAnsweredBadRequest() throws Exception {
+    public void testAnswerBadRequestInsteadOfEndlessLoop() throws Exception {
 
         HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter() {
             @Override
@@ -60,21 +64,15 @@ public class DirectRequestTest {
                 .withFiltersSource(filtersSource)//
                 .start();
 
-        socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
-
         int proxyPort = proxyServer.getListenAddress().getPort();
-        String successfulGet = "GET http://localhost:" + proxyPort + "/directToProxy HTTP/1.1\n" + "\r\n";
-        SocketClientUtil.writeStringToSocket(successfulGet, socket);
+        org.apache.http.HttpResponse response = getResponse("http://127.0.0.1:" + proxyPort + "/directToProxy");
+        int statusCode = response.getStatusLine().getStatusCode();
 
-        Thread.sleep(750);
-
-        String response = SocketClientUtil.readStringFromSocket(socket);
-
-        assertThat("Expected to receive an HTTP 400 from the server", response, startsWith("HTTP/1.1 400 "));
+        assertEquals("Expected to receive an HTTP 400 from the server", 400, statusCode);
     }
 
     @Test(timeout = 5000)
-    public void testDirectRequestAnswerUnmodified() throws Exception {
+    public void testAnswerFromFilterShouldBeServed() throws Exception {
 
         HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter() {
             @Override
@@ -93,16 +91,73 @@ public class DirectRequestTest {
                 .withFiltersSource(filtersSource)//
                 .start();
 
-        socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+        int proxyPort = proxyServer.getListenAddress().getPort();
+        org.apache.http.HttpResponse response = getResponse("http://localhost:" + proxyPort + "/directToProxy");
+        int statusCode = response.getStatusLine().getStatusCode();
+
+        assertEquals("Expected to receive an HTTP 403 from the server", 403, statusCode);
+    }
+
+    @Test(timeout = 5000, expected = SSLException.class)
+    public void testHttpsShouldCancelConnection() throws Exception {
+
+        HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter() {
+            @Override
+            public HttpFilters filterRequest(HttpRequest originalRequest) {
+                return new HttpFiltersAdapter(originalRequest) {
+                    @Override
+                    public HttpResponse clientToProxyRequest(HttpObject httpObject) {
+                        return new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(403));
+                    }
+                };
+            }
+        };
+
+        proxyServer = DefaultHttpProxyServer.bootstrap()//
+                .withPort(0)//
+                .withFiltersSource(filtersSource)//
+                .start();
 
         int proxyPort = proxyServer.getListenAddress().getPort();
-        String successfulGet = "GET http://localhost:" + proxyPort + "/directToProxy HTTP/1.1\n" + "\r\n";
-        SocketClientUtil.writeStringToSocket(successfulGet, socket);
-
-        Thread.sleep(750);
-
-        String response = SocketClientUtil.readStringFromSocket(socket);
-
-        assertThat("Expected to receive an HTTP 403 from the server", response, startsWith("HTTP/1.1 403 "));
+        getResponse("https://localhost:" + proxyPort + "/directToProxy");
     }
+
+    private DefaultHttpClient buildHttpClient() throws Exception {
+        DefaultHttpClient httpClient = new DefaultHttpClient();
+        SSLSocketFactory sf = new SSLSocketFactory(new TrustSelfSignedStrategy(), new X509HostnameVerifier() {
+            public boolean verify(String arg0, SSLSession arg1) {
+                return true;
+            }
+
+            public void verify(String host, String[] cns, String[] subjectAlts) throws SSLException {
+            }
+
+            public void verify(String host, X509Certificate cert) throws SSLException {
+            }
+
+            public void verify(String host, SSLSocket ssl) throws IOException {
+            }
+        });
+        Scheme scheme = new Scheme("https", 443, sf);
+        httpClient.getConnectionManager().getSchemeRegistry().register(scheme);
+        return httpClient;
+    }
+
+    private org.apache.http.HttpResponse getResponse(final String url) throws Exception {
+        final DefaultHttpClient http = buildHttpClient();
+
+        final HttpGet get = new HttpGet(url);
+
+        return getHttpResponse(http, get);
+    }
+
+    private org.apache.http.HttpResponse getHttpResponse(DefaultHttpClient httpClient, HttpUriRequest get)
+            throws IOException {
+        final org.apache.http.HttpResponse hr = httpClient.execute(get);
+        final HttpEntity responseEntity = hr.getEntity();
+        EntityUtils.consume(responseEntity);
+        httpClient.getConnectionManager().shutdown();
+        return hr;
+    }
+
 }

--- a/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
+++ b/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
@@ -1,0 +1,108 @@
+package org.littleshoot.proxy;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+import java.net.Socket;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.SocketClientUtil;
+
+/**
+ * This class tests direct requests to the proxy server, which causes endless
+ * loops (#205).
+ */
+public class DirectRequestTest {
+    private HttpProxyServer proxyServer;
+
+    private Socket socket;
+
+    @Before
+    public void setUp() throws Exception {
+        socket = null;
+        proxyServer = null;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            if (proxyServer != null) {
+                proxyServer.abort();
+            }
+        } finally {
+            if (socket != null) {
+                socket.close();
+            }
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void testDirectRequestAnsweredBadRequest() throws Exception {
+
+        HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter() {
+            @Override
+            public HttpFilters filterRequest(HttpRequest originalRequest) {
+                return new HttpFiltersAdapter(originalRequest);
+            }
+        };
+
+        proxyServer = DefaultHttpProxyServer.bootstrap()//
+                .withPort(0)//
+                .withFiltersSource(filtersSource)//
+                .start();
+
+        socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        int proxyPort = proxyServer.getListenAddress().getPort();
+        String successfulGet = "GET http://localhost:" + proxyPort + "/directToProxy HTTP/1.1\n" + "\r\n";
+        SocketClientUtil.writeStringToSocket(successfulGet, socket);
+
+        Thread.sleep(750);
+
+        String response = SocketClientUtil.readStringFromSocket(socket);
+
+        assertThat("Expected to receive an HTTP 400 from the server", response, startsWith("HTTP/1.1 400 "));
+    }
+
+    @Test(timeout = 5000)
+    public void testDirectRequestAnswerUnmodified() throws Exception {
+
+        HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter() {
+            @Override
+            public HttpFilters filterRequest(HttpRequest originalRequest) {
+                return new HttpFiltersAdapter(originalRequest) {
+                    @Override
+                    public HttpResponse clientToProxyRequest(HttpObject httpObject) {
+                        return new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(403));
+                    }
+                };
+            }
+        };
+
+        proxyServer = DefaultHttpProxyServer.bootstrap()//
+                .withPort(0)//
+                .withFiltersSource(filtersSource)//
+                .start();
+
+        socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        int proxyPort = proxyServer.getListenAddress().getPort();
+        String successfulGet = "GET http://localhost:" + proxyPort + "/directToProxy HTTP/1.1\n" + "\r\n";
+        SocketClientUtil.writeStringToSocket(successfulGet, socket);
+
+        Thread.sleep(750);
+
+        String response = SocketClientUtil.readStringFromSocket(socket);
+
+        assertThat("Expected to receive an HTTP 403 from the server", response, startsWith("HTTP/1.1 403 "));
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
+++ b/src/test/java/org/littleshoot/proxy/DirectRequestTest.java
@@ -9,19 +9,12 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
 import java.io.IOException;
-import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
@@ -108,35 +101,21 @@ public class DirectRequestTest {
                 .start();
     }
 
-    private DefaultHttpClient buildHttpClient() throws Exception {
-        DefaultHttpClient httpClient = new DefaultHttpClient();
-        SSLSocketFactory sf = new SSLSocketFactory(new TrustSelfSignedStrategy(), new X509HostnameVerifier() {
-            public boolean verify(String arg0, SSLSession arg1) {
-                return true;
-            }
-
-            public void verify(String host, String[] cns, String[] subjectAlts) throws SSLException {
-            }
-
-            public void verify(String host, X509Certificate cert) throws SSLException {
-            }
-
-            public void verify(String host, SSLSocket ssl) throws IOException {
-            }
-        });
-        Scheme scheme = new Scheme("https", 443, sf);
-        httpClient.getConnectionManager().getSchemeRegistry().register(scheme);
-        return httpClient;
-    }
-
+    // FIXME this was copied from
+    // org.littleshoot.proxy.HttpFilterTest.getResponse(String), but using
+    // another client here
     private org.apache.http.HttpResponse getResponse(final String url) throws Exception {
-        final DefaultHttpClient http = buildHttpClient();
+        final DefaultHttpClient http = TestUtils.buildHttpClient();
 
         final HttpGet get = new HttpGet(url);
 
         return getHttpResponse(http, get);
     }
 
+    // FIXME duplicated code, see:
+    // org.littleshoot.proxy.HttpFilterTest.getHttpResponse(DefaultHttpClient,
+    // HttpUriRequest)
+    //
     private org.apache.http.HttpResponse getHttpResponse(DefaultHttpClient httpClient, HttpUriRequest get)
             throws IOException {
         final org.apache.http.HttpResponse hr = httpClient.execute(get);

--- a/src/test/java/org/littleshoot/proxy/TestUtils.java
+++ b/src/test/java/org/littleshoot/proxy/TestUtils.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.sun.management.UnixOperatingSystemMXBean;
+
 import org.apache.http.HttpHost;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.params.ConnRoutePNames;
@@ -378,5 +379,36 @@ public class TestUtils {
         OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
 
         return (osMxBean instanceof UnixOperatingSystemMXBean);
+    }
+
+    /**
+     * Creates a DefaultHttpClient instance.
+     * 
+     * @return instance of DefaultHttpClient
+     */
+    public static DefaultHttpClient buildHttpClient() throws Exception {
+        DefaultHttpClient httpClient = new DefaultHttpClient();
+        SSLSocketFactory sf = new SSLSocketFactory(
+                new TrustSelfSignedStrategy(), new X509HostnameVerifier() {
+                    public boolean verify(String arg0, SSLSession arg1) {
+                        return true;
+                    }
+
+                    public void verify(String host, String[] cns,
+                            String[] subjectAlts)
+                            throws SSLException {
+                    }
+
+                    public void verify(String host, X509Certificate cert)
+                            throws SSLException {
+                    }
+
+                    public void verify(String host, SSLSocket ssl)
+                            throws IOException {
+                    }
+                });
+        Scheme scheme = new Scheme("https", 443, sf);
+        httpClient.getConnectionManager().getSchemeRegistry().register(scheme);
+        return httpClient;
     }
 }


### PR DESCRIPTION
Closes #205. Tests are included. 

On requesting the proxy directly a response with a 400 bad request state is returned. It's neccessary to respect HTTPS connections while detecting proxy connections. If the proxy application reacts with its own responses, this is preferred.