### PR TITLE
update of LittleProxy 0.5.3 to work with Netty 3.10.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
-      <version>3.6.5.Final</version>
+      <version>3.10.4.Final</version>
       <scope>compile</scope>
     </dependency>
 

--- a/src/main/java/org/littleshoot/proxy/DefaultProxyAuthorizationManager.java
+++ b/src/main/java/org/littleshoot/proxy/DefaultProxyAuthorizationManager.java
@@ -32,7 +32,7 @@ public class DefaultProxyAuthorizationManager implements
 
     public boolean handleProxyAuthorization(final HttpRequest request,
         final ChannelHandlerContext ctx) {
-        if (!request.containsHeader(HttpHeaders.Names.PROXY_AUTHORIZATION)) {
+        if (!request.headers().contains(HttpHeaders.Names.PROXY_AUTHORIZATION)) {
             if (!handlers.isEmpty()) {
                 rejectRequest(ctx);
                 return false;
@@ -41,7 +41,7 @@ public class DefaultProxyAuthorizationManager implements
         }
         
         final List<String> values = 
-            request.getHeaders(HttpHeaders.Names.PROXY_AUTHORIZATION);
+            request.headers().getAll(HttpHeaders.Names.PROXY_AUTHORIZATION);
         final String fullValue = values.iterator().next();
         final String value =
             StringUtils.substringAfter(fullValue, "Basic ").trim();
@@ -64,9 +64,9 @@ public class DefaultProxyAuthorizationManager implements
         log.info("Got proxy authorization!");
         // We need to remove the header before sending the request on.
         final String authentication = 
-            request.getHeader(HttpHeaders.Names.PROXY_AUTHORIZATION);
+            request.headers().get(HttpHeaders.Names.PROXY_AUTHORIZATION);
         log.info(authentication);
-        request.removeHeader(HttpHeaders.Names.PROXY_AUTHORIZATION);
+        request.headers().remove(HttpHeaders.Names.PROXY_AUTHORIZATION);
         return true;
     }
 

--- a/src/main/java/org/littleshoot/proxy/DefaultProxyCacheManager.java
+++ b/src/main/java/org/littleshoot/proxy/DefaultProxyCacheManager.java
@@ -208,26 +208,26 @@ public class DefaultProxyCacheManager implements ProxyCacheManager {
         }
         
         // Don't use the cache if the request has cookies -- security violation.
-        if (httpResponse.containsHeader(HttpHeaders.Names.SET_COOKIE)) {
+        if (httpResponse.headers().contains(HttpHeaders.Names.SET_COOKIE)) {
             log.info("Response contains set cookie header");
             return false;
         }
-        if (httpResponse.containsHeader(HttpHeaders.Names.SET_COOKIE2)) {
+        if (httpResponse.headers().contains(HttpHeaders.Names.SET_COOKIE2)) {
             log.info("Response contains set cookie2 header");
             return false;
         }
         
         /*
-        if (httpRequest.containsHeader(HttpHeaders.Names.COOKIE)) {
+        if (httpRequest.headers().contains(HttpHeaders.Names.COOKIE)) {
             log.info("Request contains Cookie header");
             return false;
         }
         */
         
         final List<String> responseControl = 
-            httpResponse.getHeaders(HttpHeaders.Names.CACHE_CONTROL);
+            httpResponse.headers().getAll(HttpHeaders.Names.CACHE_CONTROL);
         final List<String> requestControl =
-            httpRequest.getHeaders(HttpHeaders.Names.CACHE_CONTROL);
+            httpRequest.headers().getAll(HttpHeaders.Names.CACHE_CONTROL);
         final Set<String> cacheControl = new HashSet<String>();
         cacheControl.addAll(requestControl);
         cacheControl.addAll(responseControl);
@@ -261,7 +261,7 @@ public class DefaultProxyCacheManager implements ProxyCacheManager {
         }
         
         final String responsePragma = 
-            httpResponse.getHeader(HttpHeaders.Names.PRAGMA);
+            httpResponse.headers().get(HttpHeaders.Names.PRAGMA);
         if (StringUtils.isNotBlank(responsePragma) &&
             responsePragma.contains(HttpHeaders.Values.NO_CACHE)) {
             log.info("Not caching with response pragma no cache");
@@ -269,7 +269,7 @@ public class DefaultProxyCacheManager implements ProxyCacheManager {
         }
         
         final String requestPragma = 
-            httpRequest.getHeader(HttpHeaders.Names.PRAGMA);
+            httpRequest.headers().get(HttpHeaders.Names.PRAGMA);
         if (StringUtils.isNotBlank(requestPragma) &&
             requestPragma.contains(HttpHeaders.Values.NO_CACHE)) {
             log.info("Not caching with request pragma no cache");

--- a/src/main/java/org/littleshoot/proxy/HttpRelayingHandler.java
+++ b/src/main/java/org/littleshoot/proxy/HttpRelayingHandler.java
@@ -142,16 +142,16 @@ public class HttpRelayingHandler extends SimpleChannelUpstreamHandler
             final HttpResponse response;
             
             // Double check the Transfer-Encoding, since it gets tricky.
-            final String te = hr.getHeader(HttpHeaders.Names.TRANSFER_ENCODING);
+            final String te = hr.headers().get(HttpHeaders.Names.TRANSFER_ENCODING);
             if (StringUtils.isNotBlank(te) && 
                 te.equalsIgnoreCase(HttpHeaders.Values.CHUNKED)) {
                 if (hr.getProtocolVersion() != HttpVersion.HTTP_1_1) {
                     log.warn("Fixing HTTP version.");
                     response = ProxyUtils.copyMutableResponseFields(hr, 
                         new DefaultHttpResponse(HttpVersion.HTTP_1_1, hr.getStatus()));
-                    if (!response.containsHeader(HttpHeaders.Names.TRANSFER_ENCODING)) {
+                    if (!response.headers().contains(HttpHeaders.Names.TRANSFER_ENCODING)) {
                         log.debug("Adding chunked encoding header");
-                        response.addHeader(HttpHeaders.Names.TRANSFER_ENCODING, 
+                        response.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, 
                             HttpHeaders.Values.CHUNKED);
                     }
                 }
@@ -340,11 +340,11 @@ public class HttpRelayingHandler extends SimpleChannelUpstreamHandler
     }
     
     private boolean closeEndsResponseBody(final HttpResponse res) {
-        final String cl = res.getHeader(HttpHeaders.Names.CONTENT_LENGTH);
+        final String cl = res.headers().get(HttpHeaders.Names.CONTENT_LENGTH);
         if (StringUtils.isNotBlank(cl)) {
             return false;
         }
-        final String te = res.getHeader(HttpHeaders.Names.TRANSFER_ENCODING);
+        final String te = res.headers().get(HttpHeaders.Names.TRANSFER_ENCODING);
         if (StringUtils.isNotBlank(te) && 
             te.equalsIgnoreCase(HttpHeaders.Values.CHUNKED))  {
             return false;
@@ -386,13 +386,13 @@ public class HttpRelayingHandler extends SimpleChannelUpstreamHandler
         // Switch the de-facto standard "Proxy-Connection" header to 
         // "Connection" when we pass it along to the remote host.
         final String proxyConnectionKey = "Proxy-Connection";
-        if (req.containsHeader(proxyConnectionKey)) {
-            final String header = req.getHeader(proxyConnectionKey);
-            req.removeHeader(proxyConnectionKey);
+        if (req.headers().contains(proxyConnectionKey)) {
+            final String header = req.headers().get(proxyConnectionKey);
+            req.headers().remove(proxyConnectionKey);
             if (req.getProtocolVersion() == HttpVersion.HTTP_1_1) {
                 log.debug("Switching Proxy-Connection to Connection for " +
                     "analyzing request for close");
-                req.setHeader("Connection", header);
+                req.headers().set("Connection", header);
             }
         }
         

--- a/src/main/java/org/littleshoot/proxy/HttpRequestHandler.java
+++ b/src/main/java/org/littleshoot/proxy/HttpRequestHandler.java
@@ -388,7 +388,7 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler
             hostAndPort = ProxyUtils.parseHostAndPort(request);
             if (StringUtils.isBlank(hostAndPort)) {
                 final List<String> hosts = 
-                    request.getHeaders(HttpHeaders.Names.HOST);
+                    request.headers().getAll(HttpHeaders.Names.HOST);
                 if (hosts != null && !hosts.isEmpty()) {
                     hostAndPort = hosts.get(0);
                 } else {
@@ -550,11 +550,11 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler
         final HttpResponse response = 
             new DefaultHttpResponse(HttpVersion.HTTP_1_1, 
                 HttpResponseStatus.BAD_GATEWAY);
-        response.setHeader(HttpHeaders.Names.CONNECTION, "close");
+        response.headers().set(HttpHeaders.Names.CONNECTION, "close");
         final String body = "Bad Gateway: "+request.getUri();
         response.setContent(ChannelBuffers.copiedBuffer(body, 
             Charset.forName("UTF-8")));
-        response.setHeader(HttpHeaders.Names.CONTENT_LENGTH, body.length());
+        response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, body.length());
         inboundChannel.write(response);
     }
 

--- a/src/main/java/org/littleshoot/proxy/IdleRequestHandler.java
+++ b/src/main/java/org/littleshoot/proxy/IdleRequestHandler.java
@@ -38,7 +38,7 @@ public class IdleRequestHandler extends IdleAwareHandler {
             for (HttpRequest unansweredRequest : unansweredHttpRequests) {
                 // Go through each unanswered request and concat the info
                 message.append(unansweredRequest.getUri());
-                String referrer = unansweredRequest.getHeader("Referer");
+                String referrer = unansweredRequest.headers().get("Referer");
                 if (!StringUtils.isBlank(referrer)) {
                     // Capture the referrer so that slow resources can be tracked
                     // to a page

--- a/src/main/java/org/littleshoot/proxy/RegexHttpRequestFilter.java
+++ b/src/main/java/org/littleshoot/proxy/RegexHttpRequestFilter.java
@@ -85,7 +85,7 @@ public class RegexHttpRequestFilter implements HttpRequestFilter {
     
     public void filter(final HttpRequest httpRequest) {
         if (filterHosts) {
-            final List<String> hosts = httpRequest.getHeaders("Host");
+            final List<String> hosts = httpRequest.headers().getAll("Host");
             if (hosts != null) {
                 if (!hosts.isEmpty()) {
                     final String host = hosts.get(0);

--- a/src/test/java/org/littleshoot/proxy/DefaultProxyCacheManagerTest.java
+++ b/src/test/java/org/littleshoot/proxy/DefaultProxyCacheManagerTest.java
@@ -38,7 +38,7 @@ public class DefaultProxyCacheManagerTest {
                 "http://www.littleshoot.org");
         final HttpResponse httpResponse = 
             new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-        httpResponse.setHeader(HttpHeaders.Names.CACHE_CONTROL, HttpHeaders.Values.PUBLIC);
+        httpResponse.headers().set(HttpHeaders.Names.CACHE_CONTROL, HttpHeaders.Values.PUBLIC);
         final class PubEncoder extends HttpResponseEncoder {
             public Object pubEncode(ChannelHandlerContext ctx, Channel channel, Object msg) throws Exception {
                 return encode(ctx, channel, msg);

--- a/src/test/java/org/littleshoot/proxy/HttpProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpProxyTest.java
@@ -424,7 +424,7 @@ public class HttpProxyTest {
             crlf[1] = (byte) lf;
             final ChannelBuffer buf = ChannelBuffers.wrappedBuffer(crlf);
             throw new Error("Did not get expected CRLF!! Instead got hex: "+
-                ChannelBuffers.hexDump(buf)+" and str: "+buf.toString("US-ASCII"));
+                ChannelBuffers.hexDump(buf)+" and str: "+buf.toString(java.nio.charset.Charset.forName("US-ASCII")));
         }
     }
 

--- a/src/test/java/org/littleshoot/proxy/RegexHttpRequestFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/RegexHttpRequestFilterTest.java
@@ -84,7 +84,7 @@ public class RegexHttpRequestFilterTest {
 
     private HttpRequest createRequest(String url) {
         final HttpRequest request = new DefaultHttpRequest(HTTP_1_0, GET, ProxyUtils.stripHost(url));
-        request.setHeader("Host", ProxyUtils.parseHost(url));
+        request.headers().set("Host", ProxyUtils.parseHost(url));
         return request;
     }
 


### PR DESCRIPTION
Hi,


here you find changes necessary to make LittleProxy 0.3.5 compatible to Netty 3.10.4.Final. The changes are quite simple, involve just changing the access to HTTP header which was refactored on the Netty side in the meantime. These changes are valuable to people having ChannelHandlers plugged into LittleProxy which are not ported yet to Netty 4.

If you find this valueable, you may want to merge based on the littleproxy-0.3.5 tag and create a 0.3.5.1 or 0.3.6 or so...


Best regards,
   Thomas Beckmann.