### PR TITLE
Fix chained proxy disconnect hang

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
@@ -189,9 +189,11 @@ class ConnectionFlow {
                                     serverConnection,
                                     lastStateBeforeFailure,
                                     cause)) {
-                                // We are not retrying our connection, let
-                                // anyone waiting for a
-                                // connection know that we're done
+                                // the connection to the server failed and we are not retrying, so transition to the
+                                // DISCONNECTED state
+                                serverConnection.become(ConnectionState.DISCONNECTED);
+
+                                // We are not retrying our connection, let anyone waiting for a connection know that we're done
                                 notifyThreadsWaitingForConnection();
                             }
                         }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -356,9 +356,12 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             } else if (newState == DISCONNECTED) {
                 currentFilters.proxyToServerConnectionFailed();
             }
-        } else if (getCurrentState() == HANDSHAKING
-                && newState == AWAITING_INITIAL) {
-            currentFilters.proxyToServerConnectionSucceeded(ctx);
+        } else if (getCurrentState() == HANDSHAKING) {
+            if (newState == AWAITING_INITIAL) {
+                currentFilters.proxyToServerConnectionSucceeded(ctx);
+            } else if (newState == DISCONNECTED) {
+                currentFilters.proxyToServerConnectionFailed();
+            }
         } else if (getCurrentState() == AWAITING_CHUNK
                 && newState != AWAITING_CHUNK) {
             currentFilters.serverToProxyResponseReceived();
@@ -729,8 +732,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             this.connectAndWrite(initialRequest);
             return true; // yes, we fell back
         } else {
-            // nothing to fall back to. connection failed, so transition from "CONNECTING" to "DISCONNECTED".
-            become(DISCONNECTED);
+            // nothing to fall back to.
             return false;
         }
     }
@@ -945,4 +947,5 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             }
         }
     };
+
 }

--- a/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackTest.java
+++ b/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackTest.java
@@ -16,8 +16,6 @@ import org.junit.Assert;
  * connection.
  */
 public class ChainedProxyWithFallbackTest extends BaseProxyTest {
-    private static final int DOWNSTREAM_PROXY_PORT = 49999;
-
     private AtomicBoolean unableToConnect = new AtomicBoolean(false);
 
     @Override
@@ -34,9 +32,8 @@ public class ChainedProxyWithFallbackTest extends BaseProxyTest {
                             @Override
                             public InetSocketAddress getChainedProxyAddress() {
                                 try {
-                                    return new InetSocketAddress(InetAddress
-                                            .getByName("127.0.0.1"),
-                                            DOWNSTREAM_PROXY_PORT);
+                                    // using unconnectable port 0
+                                    return new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0);
                                 } catch (UnknownHostException uhe) {
                                     throw new RuntimeException(
                                             "Unable to resolve 127.0.0.1?!");

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -448,6 +448,7 @@ public class HttpFilterTest {
         setUpHttpProxyServer(filtersSource);
 
         getResponse("http://localhost:" + webServerPort + "/");
+        Thread.sleep(500);
 
         assertTrue("proxyToServerResolutionSucceeded method was not called", resolutionSucceeded.get());
     }
@@ -473,6 +474,7 @@ public class HttpFilterTest {
                 .start();
 
         getResponse("http://www.doesnotexist/some-resource");
+        Thread.sleep(500);
 
         // verify that the filters related to this functionality were correctly invoked/not invoked as appropriate, but also verify that
         // other filters were invoked/not invoked as expected
@@ -512,6 +514,7 @@ public class HttpFilterTest {
 
         // port 0 is not connectable
         getResponse("http://localhost:0/some-resource");
+        Thread.sleep(500);
 
         // verify that the filters related to this functionality were correctly invoked/not invoked as appropriate, but also verify that
         // other filters were invoked/not invoked as expected
@@ -704,6 +707,8 @@ public class HttpFilterTest {
         org.apache.http.HttpResponse httpResponse = getResponse("http://localhost:" + mockServerPort + "/servertimeout");
         assertEquals("Expected to receive an HTTP 504 Gateway Timeout from proxy", 504, httpResponse.getStatusLine().getStatusCode());
 
+        Thread.sleep(500);
+        
         // verify that the filters related to this functionality were correctly invoked/not invoked as appropriate, but also verify that
         // other filters were invoked/not invoked as expected
         assertTrue("Expected filter method to be called", filter.isServerToProxyResponseTimedOutInvoked());
@@ -763,6 +768,7 @@ public class HttpFilterTest {
 
         // test with a POST request with a payload. post a large amount of data, to force chunked content.
         postToServer("http://localhost:" + webServerPort + "/", 50000);
+        Thread.sleep(500);
 
         assertTrue("proxyToServerRequest callback was not invoked for LastHttpContent for chunked POST", lastHttpContentProcessed.get());
         assertTrue("proxyToServerRequestSent callback was not invoked for chunked POST", requestSentCallbackInvoked.get());


### PR DESCRIPTION
I noticed a few of the unit tests were taking over 30s to complete. I discovered that chained proxy connection failures were not properly transitioning the server's connection state to DISCONNECTED, so any subsequent writes from the client would hang for 30s waiting for the server to connect.

This PR also fixes a related issue where encrypted upstream proxy connection failures did not invoke the proxyToServerConnectionFailed() filter method.

I also added 500ms sleeps in the HttpFilterTests to allow the filters to fire after requests are sent.

As a result of these fixes, unit tests finish about 1m faster and are more reliable.