### PR TITLE
ProxyToServerConnection localAddress usage

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -611,7 +611,6 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                     proxyServer.getConnectTimeout());
 
             if (localAddress != null) {
-                cb.bind(localAddress);
                 return cb.connect(remoteAddress, localAddress);
             } else {
                 return cb.connect(remoteAddress);


### PR DESCRIPTION
Seems to call both "bind" and "connect" on the Bootstrap. This was not working until I removed the "bind" call. The "connect" is all that is needed.