### PR TITLE
Fix for null HttpFilters instance

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -186,9 +186,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         this.currentFilters = initialFilters;
 
         // Report connection status to HttpFilters
-        if (currentFilters != null) {
-            currentFilters.proxyToServerConnectionQueued();
-        }
+        currentFilters.proxyToServerConnectionQueued();
 
         setupConnectionParameters();
     }
@@ -213,9 +211,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     protected ConnectionState readHTTPInitial(HttpResponse httpResponse) {
         LOG.debug("Received raw response: {}", httpResponse);
 
-        if (currentFilters != null) {
-            currentFilters.serverToProxyResponseReceiving();
-        }
+        currentFilters.serverToProxyResponseReceiving();
 
         rememberCurrentResponse(httpResponse);
         respondWith(httpResponse);
@@ -223,9 +219,8 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         if (ProxyUtils.isChunked(httpResponse)) {
             return AWAITING_CHUNK;
         } else {
-            if (currentFilters != null) {
-                currentFilters.serverToProxyResponseReceived();
-            }
+            currentFilters.serverToProxyResponseReceived();
+
             return AWAITING_INITIAL;
         }
     }
@@ -352,27 +347,25 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     @Override
     protected void become(ConnectionState newState) {
         // Report connection status to HttpFilters
-        if (currentFilters != null) {
-            if (getCurrentState() == DISCONNECTED && newState == CONNECTING) {
-                currentFilters.proxyToServerConnectionStarted();
-            } else if (getCurrentState() == CONNECTING) {
-                if (newState == HANDSHAKING) {
-                    currentFilters.proxyToServerConnectionSSLHandshakeStarted();
-                } else if (newState == AWAITING_INITIAL) {
-                    currentFilters.proxyToServerConnectionSucceeded(ctx);
-                } else if (newState == DISCONNECTED) {
-                    currentFilters.proxyToServerConnectionFailed();
-                }
-            } else if (getCurrentState() == HANDSHAKING) {
-                if (newState == AWAITING_INITIAL) {
-                    currentFilters.proxyToServerConnectionSucceeded(ctx);
-                } else if (newState == DISCONNECTED) {
-                    currentFilters.proxyToServerConnectionFailed();
-                }
-            } else if (getCurrentState() == AWAITING_CHUNK
-                    && newState != AWAITING_CHUNK) {
-                currentFilters.serverToProxyResponseReceived();
+        if (getCurrentState() == DISCONNECTED && newState == CONNECTING) {
+            currentFilters.proxyToServerConnectionStarted();
+        } else if (getCurrentState() == CONNECTING) {
+            if (newState == HANDSHAKING) {
+                currentFilters.proxyToServerConnectionSSLHandshakeStarted();
+            } else if (newState == AWAITING_INITIAL) {
+                currentFilters.proxyToServerConnectionSucceeded(ctx);
+            } else if (newState == DISCONNECTED) {
+                currentFilters.proxyToServerConnectionFailed();
             }
+        } else if (getCurrentState() == HANDSHAKING) {
+            if (newState == AWAITING_INITIAL) {
+                currentFilters.proxyToServerConnectionSucceeded(ctx);
+            } else if (newState == DISCONNECTED) {
+                currentFilters.proxyToServerConnectionFailed();
+            }
+        } else if (getCurrentState() == AWAITING_CHUNK
+                && newState != AWAITING_CHUNK) {
+            currentFilters.serverToProxyResponseReceived();
         }
 
         super.become(newState);
@@ -761,9 +754,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             this.transportProtocol = TransportProtocol.TCP;
 
             // Report DNS resolution to HttpFilters
-            if (this.currentFilters != null) {
-                this.remoteAddress = this.currentFilters.proxyToServerResolutionStarted(serverHostAndPort);
-            }
+            this.remoteAddress = this.currentFilters.proxyToServerResolutionStarted(serverHostAndPort);
 
             // save the hostname and port of the unresolved address in hostAndPort, in case name resolution fails
             String hostAndPort = null;
@@ -780,16 +771,12 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             } catch (UnknownHostException e) {
                 // unable to resolve the hostname to an IP address. notify the filters of the failure before allowing the
                 // exception to bubble up.
-                if (this.currentFilters != null) {
-                    this.currentFilters.proxyToServerResolutionFailed(hostAndPort);
-                }
+                this.currentFilters.proxyToServerResolutionFailed(hostAndPort);
 
                 throw e;
             }
 
-            if (this.currentFilters != null) {
-                this.currentFilters.proxyToServerResolutionSucceeded(serverHostAndPort, this.remoteAddress);
-            }
+            this.currentFilters.proxyToServerResolutionSucceeded(serverHostAndPort, this.remoteAddress);
 
 
             this.localAddress = proxyServer.getLocalAddress();
@@ -948,9 +935,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 LOG.warn("Error while invoking ActivityTracker on request", t);
             }
 
-            if (currentFilters != null) {
-                currentFilters.proxyToServerRequestSending();
-            }
+            currentFilters.proxyToServerRequestSending();
         }
 
         @Override
@@ -960,9 +945,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         @Override
         protected void contentWritten(HttpContent httpContent) {
             if (httpContent instanceof LastHttpContent) {
-                if (currentFilters != null) {
-                    currentFilters.proxyToServerRequestSent();
-                }
+                currentFilters.proxyToServerRequestSent();
             }
         }
     };

--- a/src/test/java/org/littleshoot/proxy/TimeoutTest.java
+++ b/src/test/java/org/littleshoot/proxy/TimeoutTest.java
@@ -10,14 +10,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.littleshoot.proxy.test.SocketClientUtil;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
 import org.mockserver.model.Delay;
 
 import java.io.IOException;
+import java.net.Socket;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockserver.model.HttpRequest.request;
@@ -102,5 +105,34 @@ public class TimeoutTest {
         assertEquals("Expected to receive an HTTP 502 (Bad Gateway) response after proxy could not connect within 1 second", 502, response.getStatusLine().getStatusCode());
         assertThat("Expected connection timeout to happen after approximately 1 second",
                 TimeUnit.MILLISECONDS.convert(stop - start, TimeUnit.NANOSECONDS), lessThan(2000L));
+    }
+
+    /**
+     * Verifies that when the client times out sending the initial request, the proxy still returns a Gateway Timeout.
+     */
+    @Test
+    public void testClientIdleBeforeRequestReceived() throws IOException, InterruptedException {
+        this.proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .withIdleConnectionTimeout(1)
+                .start();
+
+        // connect to the proxy and begin to transmit the request, but don't send the trailing \r\n that indicates the client has completely transmitted the request
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1";
+
+        // using the SocketClientUtil since we want the client to fail to send the entire GET request, which is not possible with
+        // Apache HTTP client and most other HTTP clients
+        Socket socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
+
+        SocketClientUtil.writeStringToSocket(successfulGet, socket);
+
+        // wait a bit to allow the proxy server to respond
+        Thread.sleep(1500);
+
+        // the proxy should return an HTTP 504 due to the timeout
+        String response = SocketClientUtil.readStringFromSocket(socket);
+        assertThat("Expected to receive an HTTP 504 Gateway Timeout from the server", response, startsWith("HTTP/1.1 504"));
+
+        socket.close();
     }
 }


### PR DESCRIPTION
The [javadoc for HttpFiltersSource](https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/HttpFiltersSource.java#L20) states:
```
Return an {@link HttpFilters} object for this request if and only if we 
want to filter request and/or its responses.
```

The "if and only if" part implies that the HttpFiltersSource should not return an HttpFilters instance (i.e. should return null) if we do not want to filter this request/response. Currently, this behavior is broken, and causes NPEs.

In addition to the scenario where the HttpFiltersSource returns a null HttpFilters, the HttpFilters will also be null when the client request times out. Currently this scenario also causes NPEs.

This PR addresses both scenarios by skipping filter calls when the filters are null. I've also added tests for both scenarios.