### PR TITLE
Fix for null exception messages in exceptionCaught()

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -720,15 +720,19 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
     @Override
     protected void exceptionCaught(Throwable cause) {
-        String message = "Caught an exception on ClientToProxyConnection";
-        boolean shouldWarn = cause instanceof ClosedChannelException ||
-                cause.getMessage().contains("Connection reset by peer");
-        if (shouldWarn) {
-            LOG.warn(message, cause);
-        } else {
-            LOG.error(message, cause);
+        try {
+            if (cause instanceof ClosedChannelException ||
+                    (cause.getMessage() != null && cause.getMessage().contains("Connection reset by peer"))) {
+                LOG.warn("Caught an exception on ClientToProxyConnection", cause);
+            } else {
+                LOG.error("Caught an exception on ClientToProxyConnection", cause);
+            }
+        } finally {
+            // always disconnect the client when an exception occurs on the channel
+            disconnect();
         }
-        disconnect();
+
+
     }
 
     /***************************************************************************

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -405,25 +405,27 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
     @Override
     protected void exceptionCaught(Throwable cause) {
-        String message = "Caught exception on proxy -> web connection";
         int logLevel = LocationAwareLogger.WARN_INT;
-        if (cause != null) {
-            String causeMessage = cause.getMessage();
-            if (cause instanceof ConnectException) {
-                logLevel = LocationAwareLogger.DEBUG_INT;
-            } else if (causeMessage != null) {
-                if (causeMessage.contains("Connection reset by peer")) {
+        try {
+            if (cause != null) {
+                String causeMessage = cause.getMessage();
+                if (cause instanceof ConnectException) {
                     logLevel = LocationAwareLogger.DEBUG_INT;
-                } else if (causeMessage.contains("event executor terminated")) {
-                    logLevel = LocationAwareLogger.DEBUG_INT;
+                } else if (causeMessage != null) {
+                    if (causeMessage.contains("Connection reset by peer")) {
+                        logLevel = LocationAwareLogger.DEBUG_INT;
+                    } else if (causeMessage.contains("event executor terminated")) {
+                        logLevel = LocationAwareLogger.DEBUG_INT;
+                    }
                 }
             }
-        }
-        LOG.log(logLevel, message, cause);
 
-        if (!is(DISCONNECTED)) {
-            LOG.log(logLevel, "Disconnecting open connection");
-            disconnect();
+            LOG.log(logLevel, "Caught an exception on ProxyToServerConnection", cause);
+        } finally {
+            if (!is(DISCONNECTED)) {
+                LOG.log(logLevel, "Disconnecting open connection");
+                disconnect();
+            }
         }
         // This can happen if we couldn't make the initial connection due
         // to something like an unresolved address, for example, or a timeout.


### PR DESCRIPTION
I encountered a minor issue where an UnsupportedOperationException with a null exception.getMessage() was causing a NPE in ClientToProxyConnection.exceptionCaught(). This PR fixes the exception.getMessage() NPE, and moves the disconnect() into a finally block in exceptionCaught().