### PR TITLE
Add netty-4.1 profile for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,13 @@
                 <javadoc.opts />
             </properties>
         </profile>
+
+        <profile>
+            <id>netty-4.1</id>
+            <properties>
+                <netty.version>4.1.0.Beta6</netty.version>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencies>


### PR DESCRIPTION
This small change makes testing LittleProxy against Netty 4.1 a bit easier. For example:
```sh
mvn clean test -P netty-4.1
```
Will run all our tests against the Netty 4.1 version specified in the profile (currently 4.1.0.Beta6).

The profile is not and should not be used for releases, and has no effect whatsoever on travis-ci builds.