### PR TITLE
Transparent proxy sends URI with host

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -1040,6 +1040,14 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private void modifyRequestHeadersToReflectProxying(HttpRequest httpRequest) {
         if (!currentServerConnection.hasUpstreamChainedProxy()) {
+            /*
+             * We are making the request to the origin server, so must modify
+             * the 'absolute-URI' into the 'origin-form' as per RFC 7230
+             * section 5.3.1.
+             *
+             * This must happen even for 'transparent' mode, otherwise the origin
+             * server could infer that the request came via a proxy server.
+             */
             LOG.debug("Modifying request for proxy chaining");
             // Strip host from uri
             String uri = httpRequest.getUri();

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -1039,18 +1039,17 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * @param httpRequest
      */
     private void modifyRequestHeadersToReflectProxying(HttpRequest httpRequest) {
+        if (!currentServerConnection.hasUpstreamChainedProxy()) {
+            LOG.debug("Modifying request for proxy chaining");
+            // Strip host from uri
+            String uri = httpRequest.getUri();
+            String adjustedUri = ProxyUtils.stripHost(uri);
+            LOG.debug("Stripped host from uri: {}    yielding: {}", uri,
+                    adjustedUri);
+            httpRequest.setUri(adjustedUri);
+        }
         if (!proxyServer.isTransparent()) {
             LOG.debug("Modifying request headers for proxying");
-
-            if (!currentServerConnection.hasUpstreamChainedProxy()) {
-                LOG.debug("Modifying request for proxy chaining");
-                // Strip host from uri
-                String uri = httpRequest.getUri();
-                String adjustedUri = ProxyUtils.stripHost(uri);
-                LOG.debug("Stripped host from uri: {}    yielding: {}", uri,
-                        adjustedUri);
-                httpRequest.setUri(adjustedUri);
-            }
 
             HttpHeaders headers = httpRequest.headers();
 

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -187,8 +187,10 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
      * @param filtersSource
      *            Source for {@link HttpFilters}
      * @param transparent
-     *            If true, this proxy will run as a transparent proxy (not
-     *            touching requests and responses).
+     *            If true, this proxy will run as a transparent proxy. This will
+     *            not modify the response, and will only modify the request to
+     *            amend the URI if the target is the origin server (to comply
+     *            with RFC 7230 section 5.3.1).
      * @param idleConnectionTimeout
      *            The timeout (in seconds) for auto-closing idle connections.
      * @param activityTrackers


### PR DESCRIPTION
When the transparent configuration option is enabled, the request URI is not modified to remove the authority part. That is "http://example.org/path" is sent to the HTTP server rather than just "/path". 

The host adjustment is currently done when "transparent" mode is false, so this logic just needs to be moved out of the "transparent" check. 

It seems that some HTTP servers handle the full URI robustly, but others 404 if the authority is present (for example http://www.baidu.com/s).