### PR TITLE
Localization-specific exception cleanup

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -33,6 +33,7 @@ import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.SslEngineSource;
 
 import javax.net.ssl.SSLSession;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -44,6 +45,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
@@ -721,9 +723,15 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     @Override
     protected void exceptionCaught(Throwable cause) {
         try {
-            if (cause instanceof ClosedChannelException ||
-                    (cause.getMessage() != null && cause.getMessage().contains("Connection reset by peer"))) {
-                LOG.warn("Caught an exception on ClientToProxyConnection", cause);
+            if (cause instanceof IOException) {
+                // IOExceptions are expected errors, for example when a browser is killed and aborts a connection.
+                // rather than flood the logs with stack traces for these expected exceptions, we log the message at the
+                // INFO level and the stack trace at the DEBUG level.
+                LOG.info("An IOException occurred on ClientToProxyConnection: " + cause.getMessage());
+                LOG.debug("An IOException occurred on ClientToProxyConnection", cause);
+            } else if (cause instanceof RejectedExecutionException) {
+                LOG.info("An executor rejected a read or write operation on the ClientToProxyConnection (this is normal if the proxy is shutting down). Message: " + cause.getMessage());
+                LOG.debug("A RejectedExecutionException occurred on ClientToProxyConnection", cause);
             } else {
                 LOG.error("Caught an exception on ClientToProxyConnection", cause);
             }
@@ -731,8 +739,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             // always disconnect the client when an exception occurs on the channel
             disconnect();
         }
-
-
     }
 
     /***************************************************************************


### PR DESCRIPTION
As suggested by @ganskef in PR #240, this change removes the localization-specific exception checking in the exceptionCaught() methods. It also moves  stack traces for IOException and RejectedExecutionExceptions from the INFO level to the DEBUG level, which will eliminate some log spam.