### PR TITLE
Made withMITM and withSSLEngineSource mutually exclusive and changed API docs

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -100,6 +100,11 @@ public interface HttpProxyServerBootstrap {
      * Default = null
      * </p>
      * 
+     * <p>
+     * Note - This and {@link #withManInTheMiddle(MitmManager)} are
+     * mutually exclusive.
+     * </p>
+     * 
      * @param sslEngineSource
      * @return
      */
@@ -148,11 +153,6 @@ public interface HttpProxyServerBootstrap {
      * Default = null
      * </p>
      * 
-     * <p>
-     * Note - This and {@link #withManInTheMiddle(MitmManager)} are currently
-     * mutually exclusive.
-     * </p>
-     * 
      * @param chainProxyManager
      * @return
      */
@@ -170,8 +170,8 @@ public interface HttpProxyServerBootstrap {
      * </p>
      * 
      * <p>
-     * Note - This and {@link #withChainProxyManager(ChainedProxyManager)} are
-     * currently mutually exclusive.
+     * Note - This and {@link #withSslEngineSource(SslEngineSource)} are
+     * mutually exclusive.
      * </p>
      * 
      * @param mitmManager

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -690,6 +690,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             if (this.mitmManager != null) {
                 LOG.warn("Enabled encrypted inbound connections with man in the middle. "
                         + "These are mutually exclusive - man in the middle will be disabled.");
+                this.mitmManager = null;
             }
             return this;
         }
@@ -722,6 +723,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
             if (this.sslEngineSource != null) {
                 LOG.warn("Enabled man in the middle with encrypted inbound connections. "
                         + "These are mutually exclusive - encrypted inbound connections will be disabled.");
+                this.sslEngineSource = null;
             }
             return this;
         }

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -687,6 +687,10 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         public HttpProxyServerBootstrap withSslEngineSource(
                 SslEngineSource sslEngineSource) {
             this.sslEngineSource = sslEngineSource;
+            if (this.mitmManager != null) {
+                LOG.warn("Enabled encrypted inbound connections with man in the middle. "
+                        + "These are mutually exclusive - man in the middle will be disabled.");
+            }
             return this;
         }
 
@@ -708,9 +712,6 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         public HttpProxyServerBootstrap withChainProxyManager(
                 ChainedProxyManager chainProxyManager) {
             this.chainProxyManager = chainProxyManager;
-            if (this.mitmManager != null) {
-                LOG.info("Enabled proxy chaining with man in the middle.");
-            }
             return this;
         }
 
@@ -718,8 +719,9 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         public HttpProxyServerBootstrap withManInTheMiddle(
                 MitmManager mitmManager) {
             this.mitmManager = mitmManager;
-            if (this.chainProxyManager != null) {
-                LOG.info("Enabled man in the middle along with proxy chaining.");
+            if (this.sslEngineSource != null) {
+                LOG.warn("Enabled man in the middle with encrypted inbound connections. "
+                        + "These are mutually exclusive - encrypted inbound connections will be disabled.");
             }
             return this;
         }


### PR DESCRIPTION
Motivation:

`withSslEngineSource()` and `withManInTheMiddle()` are mutually exclusive as both will require SSL to be enabled for inbound connections. However only one can be enabled.

Modifications:

Modified the API docs to mention this. Modified the implementation in `DefaultHttpProxyServer` to accommodate this. Also corrected the API docs of `withChainProxyManager` and `withManInTheMiddle`