### PR TITLE
Ignore most exceptions while getting host name to avoid cancellation.

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -19,8 +19,8 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -514,10 +514,16 @@ public class ProxyUtils {
     public static String getHostName() {
         try {
             return InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            LOG.warn("Could not lookup localhost", e);
-            return null;
+        } catch (IOException e) {
+            LOG.debug("Ignored exception", e);
+        } catch (RuntimeException e) {
+            // An exception here must not stop the proxy. Android could throw a
+            // runtime exception, since it not allows network access in the main
+            // process.
+            LOG.debug("Ignored exception", e);
         }
+        LOG.info("Could not lookup localhost");
+        return null;
     }
 
     /**


### PR DESCRIPTION
Motivation:
 * Android 4.4.4 throws a RuntimeException which aborts the proxy on start up.
 * IO always must not be reliable (especially for offline use cases), so exceptions should be ignored.
 * Returning null is valid for the method, so the log level should be reduced to info. 

Modifications:
 * Catch IOException and RuntimeException with a single info log line. 
 * Log the stacktrace if debug enabled only.