### PR TITLE
Fix for ProxyAuthenticator failing on Android

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -34,7 +34,6 @@ import org.littleshoot.proxy.SslEngineSource;
 
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.channels.ClosedChannelException;
@@ -954,22 +953,16 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         List<String> values = request.headers().getAll(
                 HttpHeaders.Names.PROXY_AUTHORIZATION);
         String fullValue = values.iterator().next();
-        String value = StringUtils.substringAfter(fullValue, "Basic ")
-                .trim();
-        byte[] decodedValue = Base64.decodeBase64(value);
-        try {
-            String decodedString = new String(decodedValue, "UTF-8");
-            String userName = StringUtils.substringBefore(decodedString,
-                    ":");
-            String password = StringUtils.substringAfter(decodedString,
-                    ":");
-            if (!authenticator.authenticate(userName,
-                    password)) {
-                writeAuthenticationRequired();
-                return true;
-            }
-        } catch (UnsupportedEncodingException e) {
-            LOG.error("Could not decode?", e);
+        String value = StringUtils.substringAfter(fullValue, "Basic ").trim();
+        
+        byte[] decodedValue = Base64.decodeBase64(value.getBytes(Charset.forName("UTF-8")));
+        String decodedString = new String(decodedValue, Charset.forName("UTF-8"));
+        
+        String userName = StringUtils.substringBefore(decodedString, ":");
+        String password = StringUtils.substringAfter(decodedString, ":");
+        if (!authenticator.authenticate(userName, password)) {
+            writeAuthenticationRequired();
+            return true;
         }
 
         LOG.info("Got proxy authorization!");


### PR DESCRIPTION
Motivation : 

Using a ProxyAuthenticator when Littleproxy is run on Android causes a crash. This is because Android uses the [1.2 version of commons codec](https://android.googlesource.com/platform/external/apache-http/+/master/src/org/apache/commons/codec/binary/Base64.java) which does not contain the [Base64.decodeBase64(String) API](http://grepcode.com/file/repo1.maven.org/maven2/commons-codec/commons-codec/1.10/org/apache/commons/codec/binary/Base64.java#Base64.decodeBase64%28java.lang.String%29) which was introduced in 1.4 version of commons codec. 

Modification : 

In this PR, I have - 
(1) Used Base64.decodeBase64(byte[]) instead of Base64.decodeBase64(String) and I have used string.getBytes(Charset) to get the byte[] for the UTF-8 Charset. This is what Base64.decodeBase64(String) does in its implementation and hence will not change any behavior.
(2) Modified another usage of the string 'UTF-8' in the next line and replaced it with the charset using
Charset.forName("UTF-8"). This removes the handling of UnsupportedEncodingException.
(3) Reformatted the code in this section to make it more easy-to-read.