### PR TITLE
Mention withAuthenticateSslClients is true by default in javadocs

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -93,7 +93,8 @@ public interface HttpProxyServerBootstrap {
     /**
      * <p>
      * Specify an {@link SslEngineSource} to use for encrypting inbound
-     * connections.
+     * connections. Enabling this will enable SSL client authentication
+     * by default (see {@link #withAuthenticateSslClients(boolean)})
      * </p>
      * 
      * <p>


### PR DESCRIPTION
Modified the javadocs of withSslEngineSource to mention that
withAuthenticateSslClients is enabled by default. Temporary solution for
issue #252