### PR TITLE
Fix for ClientToProxyConnection.copy() not copying headers

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -4,9 +4,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -1013,13 +1013,13 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * @return
      */
     private HttpRequest copy(HttpRequest original) {
-        if (original instanceof DefaultFullHttpRequest) {
-            ByteBuf content = ((DefaultFullHttpRequest) original).content();
-            return new DefaultFullHttpRequest(original.getProtocolVersion(),
-                    original.getMethod(), original.getUri(), content);
+        if (original instanceof FullHttpRequest) {
+            return ((FullHttpRequest) original).copy();
         } else {
-            return new DefaultHttpRequest(original.getProtocolVersion(),
+            HttpRequest request = new DefaultHttpRequest(original.getProtocolVersion(),
                     original.getMethod(), original.getUri());
+            request.headers().set(original.headers());
+            return request;
         }
     }
 


### PR DESCRIPTION
Fix for https://github.com/adamfisk/LittleProxy/issues/271