### PR TITLE
Fix tests under travis-ci

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,10 +399,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <configuration>
-                    <forkCount>1</forkCount>
-                    <reuseForks>true</reuseForks>
+                    <argLine>-Xmx1g -XX:MaxPermSize=256m</argLine>
                 </configuration>
             </plugin>
 
@@ -532,7 +531,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <configuration>
                     <showSuccess>false</showSuccess>
                 </configuration>


### PR DESCRIPTION
I noticed that tests started failing under travis-ci a while ago. The same thing happened with BrowserMob Proxy, and I was able to solve it by giving surefire more memory.

I'm not sure what changed in the travis-ci build that caused the default heap space to be reduced, or alternately, caused LP to start using more memory (tests have always passed for me locally). In any case, this does fix or at least work around the issue.