### PR TITLE
Netty and slf4j updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>2.52.0</version>
+            <version>2.46.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <netty.version>4.0.23.Final</netty.version>
+        <netty.version>4.0.34.Final</netty.version>
+        <slf4j.version>1.7.18</slf4j.version>
     </properties>
 
     <organization>
@@ -83,7 +84,7 @@
         <profile>
             <id>netty-4.1</id>
             <properties>
-                <netty.version>4.1.0.Beta6</netty.version>
+                <netty.version>4.1.0.CR3</netty.version>
             </properties>
         </profile>
     </profiles>
@@ -150,14 +151,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.0.31-beta</version>
+            <version>2.0.44-beta</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>3.9.17</version>
+            <version>3.10.4</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -170,7 +171,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>2.46.0</version>
+            <version>2.52.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -190,7 +191,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5</version>
+            <version>4.5.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -228,14 +229,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.12</version>
+            <version>${slf4j.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.12</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
Updating to the latest netty and slf4j (binary compatible with earlier slf4j), in advance of a new beta release to Central. Also updates miscellaneous test dependencies.