### PR TITLE
Fixed unused uri for bad gateway test.

### DIFF
--- a/src/test/java/org/littleshoot/proxy/TimeoutTest.java
+++ b/src/test/java/org/littleshoot/proxy/TimeoutTest.java
@@ -27,6 +27,9 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 public class TimeoutTest {
+
+    private static final String UNUSED_URI_FOR_BAD_GATEWAY = "http://1.2.3.6:53540";
+
     private ClientAndServer mockServer;
     private int mockServerPort;
 
@@ -94,7 +97,7 @@ public class TimeoutTest {
         final HttpHost proxy = new HttpHost("127.0.0.1", proxyServer.getListenAddress().getPort(), "http");
         httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
 
-        HttpGet get = new HttpGet("http://1.2.3.4:53540");
+        HttpGet get = new HttpGet(UNUSED_URI_FOR_BAD_GATEWAY);
 
         long start = System.nanoTime();
         HttpResponse response = httpClient.execute(get);


### PR DESCRIPTION
My cell phone provider in Germany use the IP address 1.2.3.4 for the ByteMobile Inc. [BMI](http://www.bloomberg.com/profiles/companies/586816Z:US-bytemobile-inc) service. It is a service not claimed by me as I know to save traffic by modify content and compress images. So this IP is used and breaks the test and the build.

I've simply tried 1.2.3.6 and it's working for me.