### PR TITLE
Allow changing the connect timeout after the proxy is started

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServer.java
@@ -12,6 +12,16 @@ public interface HttpProxyServer {
     void setIdleConnectionTimeout(int idleConnectionTimeout);
 
     /**
+     * Returns the maximum time to wait, in milliseconds, to connect to a server.
+     */
+    int getConnectTimeout();
+
+    /**
+     * Sets the maximum time to wait, in milliseconds, to connect to a server.
+     */
+    void setConnectTimeout(int connectTimeoutMs);
+
+    /**
      * <p>
      * Clone the existing server, with a port 1 higher and everything else the
      * same. If the proxy was started with port 0 (JVM-assigned port), the cloned proxy will also use a JVM-assigned

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -106,7 +106,7 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     private final MitmManager mitmManager;
     private final HttpFiltersSource filtersSource;
     private final boolean transparent;
-    private final int connectTimeout;
+    private volatile int connectTimeout;
     private volatile int idleConnectionTimeout;
     private final HostResolver serverResolver;
     private volatile GlobalTrafficShapingHandler globalTrafficShapingHandler;
@@ -299,16 +299,24 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         return transparent;
     }
 
+    @Override
     public int getIdleConnectionTimeout() {
         return idleConnectionTimeout;
     }
 
+    @Override
     public void setIdleConnectionTimeout(int idleConnectionTimeout) {
         this.idleConnectionTimeout = idleConnectionTimeout;
     }
 
+    @Override
     public int getConnectTimeout() {
         return connectTimeout;
+    }
+
+    @Override
+    public void setConnectTimeout(int connectTimeoutMs) {
+        this.connectTimeout = connectTimeoutMs;
     }
 
     public HostResolver getServerResolver() {


### PR DESCRIPTION
Currently, the idle connection timeout can be changed after the proxy is started, but the connect timeout cannot be. ProxyToServerConnection already gets the timeout from the proxy server every time a new connection is created ([code](https://github.com/adamfisk/LittleProxy/blob/master/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java#L637)), so this is a pretty straightforward solution.

