### PR TITLE
Retrying connections without SNI after unrecognized_name failure

### DIFF
--- a/src/main/java/org/littleshoot/proxy/MitmManager.java
+++ b/src/main/java/org/littleshoot/proxy/MitmManager.java
@@ -9,19 +9,22 @@ import javax.net.ssl.SSLSession;
  */
 public interface MitmManager {
     /**
-     * Creates an {@link SSLEngine} for encrypting the server connection.
+     * Creates an {@link SSLEngine} for encrypting the server connection. The SSLEngine created by this method
+     * may use the given peer information to send SNI information when connecting to the upstream host.
+     *
+     * @param peerHost to start a client connection to the server.
+     * @param peerPort to start a client connection to the server.
      * 
-     * Note: Peer information is needed to send the server_name extension in
-     * handshake with Server Name Indication (SNI).
-     * 
-     * @param peerHost
-     *            to start a client connection to the server.
-     * @param peerPort
-     *            to start a client connection to the server. 
-     * 
-     * @return
+     * @return an SSLEngine used to connect to an upstream server
      */
     SSLEngine serverSslEngine(String peerHost, int peerPort);
+
+    /**
+     * Creates an {@link SSLEngine} for encrypting the server connection.
+     *
+     * @return an SSLEngine used to connect to an upstream server
+     */
+    SSLEngine serverSslEngine();
 
     /**
      * <p>
@@ -41,9 +44,8 @@ public interface MitmManager {
      * certificate.
      * </p>
      * 
-     * @param serverSslSession
-     *            the {@link SSLSession} that's been established with the server
-     * @return
+     * @param serverSslSession the {@link SSLSession} that's been established with the server
+     * @return the SSLEngine used to connect to the client
      */
     SSLEngine clientSslEngineFor(SSLSession serverSslSession);
 }

--- a/src/main/java/org/littleshoot/proxy/extras/SelfSignedMitmManager.java
+++ b/src/main/java/org/littleshoot/proxy/extras/SelfSignedMitmManager.java
@@ -1,9 +1,9 @@
 package org.littleshoot.proxy.extras;
 
+import org.littleshoot.proxy.MitmManager;
+
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
-
-import org.littleshoot.proxy.MitmManager;
 
 /**
  * {@link MitmManager} that uses self-signed certs for everything.
@@ -15,6 +15,11 @@ public class SelfSignedMitmManager implements MitmManager {
     @Override
     public SSLEngine serverSslEngine(String peerHost, int peerPort) {
         return selfSignedSslEngineSource.newSslEngine(peerHost, peerPort);
+    }
+
+    @Override
+    public SSLEngine serverSslEngine() {
+        return selfSignedSslEngineSource.newSslEngine();
     }
 
     @Override

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -36,7 +36,6 @@ import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.List;
@@ -587,14 +586,14 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         resumeReadingIfNecessary();
         HttpRequest initialRequest = serverConnection.getInitialRequest();
         try {
-            if (serverConnection.connectionFailed(cause)) {
-                LOG.info(
-                        "Failed to connect via chained proxy, falling back to next chained proxy. Last state before failure: {}",
+            boolean retrying = serverConnection.connectionFailed(cause);
+            if (retrying) {
+                LOG.debug("Failed to connect to upstream server or chained proxy. Retrying connection. Last state before failure: {}",
                         lastStateBeforeFailure, cause);
                 return true;
             } else {
                 LOG.debug(
-                        "Connection to server failed: {}.  Last state before failure: {}",
+                        "Connection to upstream server or chained proxy failed: {}.  Last state before failure: {}",
                         serverConnection.getRemoteAddress(),
                         lastStateBeforeFailure,
                         cause);


### PR DESCRIPTION
This is the PR I mentioned in issue #288. Since the details of the change are in that issue, I'll keep this description short. I do want to call out one change: At ProxyToServerConnection:581, I changed the way the the SNI peerHost is obtained when connecting to an upstream server, so that it now uses the same mechanism when connecting to a chained proxy as it does connecting to a server. Previously, it would use InetSocketAddress.getHostName(), which would cause a reverse lookup when connecting to an IP address.