### PR TITLE
Avoid reusing filters from previous requests on the same client connection

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFiltersAdapter.java
@@ -11,6 +11,11 @@ import java.net.InetSocketAddress;
  * Convenience base class for implementations of {@link HttpFilters}.
  */
 public class HttpFiltersAdapter implements HttpFilters {
+    /**
+     * A default, stateless, no-op {@link HttpFilters} instance.
+     */
+    public static final HttpFiltersAdapter NOOP_FILTER = new HttpFiltersAdapter(null);
+
     protected final HttpRequest originalRequest;
     protected final ChannelHandlerContext ctx;
 

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -220,6 +220,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         HttpFilters filterInstance = proxyServer.getFiltersSource().filterRequest(currentRequest, ctx);
         if (filterInstance != null) {
             currentFilters = filterInstance;
+        } else {
+            currentFilters = new HttpFiltersAdapter(null);
         }
 
         // Send the request through the clientToProxyRequest filter, and respond with the short-circuit response if required

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -36,7 +36,6 @@ import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.List;
@@ -124,7 +123,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     /**
      * The current filters to apply to incoming requests/chunks.
      */
-    private volatile HttpFilters currentFilters = new HttpFiltersAdapter(null);
+    private volatile HttpFilters currentFilters = HttpFiltersAdapter.NOOP_FILTER;
 
     private volatile SSLSession clientSslSession;
 
@@ -221,7 +220,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         if (filterInstance != null) {
             currentFilters = filterInstance;
         } else {
-            currentFilters = new HttpFiltersAdapter(null);
+            currentFilters = HttpFiltersAdapter.NOOP_FILTER;
         }
 
         // Send the request through the clientToProxyRequest filter, and respond with the short-circuit response if required


### PR DESCRIPTION
This is a fix for issue #277.