### PR TITLE
Fixing connection hang when handling HTTP 101 Switching Protocols 

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -367,8 +367,15 @@ public class ProxyUtils {
             //     - http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html Section 4.4
             //     - https://github.com/netty/netty/issues/222
             if (code >= 100 && code < 200) {
-                // One exception: Hixie 76 websocket handshake response
-                return !(code == 101 && !res.headers().contains(HttpHeaders.Names.SEC_WEBSOCKET_ACCEPT));
+                // According to RFC 7231, section 6.1, 1xx responses have no content (https://tools.ietf.org/html/rfc7231#section-6.2):
+                //   1xx responses are terminated by the first empty line after
+                //   the status-line (the empty line signaling the end of the header
+                //        section).
+
+                // Hixie 76 websocket handshake responses contain a 16-byte body, so their content is not empty; but Hixie 76
+                // was a draft specification that was superceded by RFC 6455. Since it is rarely used and doesn't conform to
+                // RFC 7231, we do not support or make special allowance for Hixie 76 responses.
+                return true;
             }
 
             switch (code) {

--- a/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
+++ b/src/test/java/org/littleshoot/proxy/impl/ProxyUtilsTest.java
@@ -126,6 +126,22 @@ public class ProxyUtilsTest {
         isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
         assertEquals(true, isResponseSelfTerminating);
 
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT);
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.RESET_CONTENT);
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
+        httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_MODIFIED);
+        isResponseSelfTerminating = ProxyUtils.isResponseSelfTerminating(httpResponse);
+        assertEquals(true, isResponseSelfTerminating);
+
         // #2: 2.If a Transfer-Encoding header field (section 14.41) is present and has any value other than "identity", then the transfer-length is defined by use of the "chunked" transfer-coding (section 3.6), unless the message is terminated by closing the connection.
         httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
         httpResponse.headers().add(HttpHeaders.Names.TRANSFER_ENCODING, "chunked");


### PR DESCRIPTION
Currently, the proxy hangs when handing a 101 response code (typically, a WebSocket Upgrade request). LP does not properly determine that the 101 response has no body, so it instead assumes the server will close the connection when the 101 response body is transmitted.

From [RFC 7231 section 6.2](https://tools.ietf.org/html/rfc7231#section-6.2):
>  1xx responses are terminated by the first empty line after
   the status-line (the empty line signaling the end of the header
   section).

Ultimately, the problem stems from some special handling for Hixie 76 WebSockets in a netty method we copied. The netty code itself contains a defect when handling non-WebSockets 101's (I plan to open an issue for that). But I propose that we completely drop support for Hixie 76 WebSockets. It was a draft spec that was superseded by the final WebSockets spec, and due to its message body, it violates RFC 7231. So rather than create additional special handling in LP for it, I propose we simplify LP and drop it entirely.