### PR TITLE
Added HttpRequest to MitmManager.clientSslEngineFor()

### DIFF
--- a/src/main/java/org/littleshoot/proxy/MitmManager.java
+++ b/src/main/java/org/littleshoot/proxy/MitmManager.java
@@ -1,5 +1,7 @@
 package org.littleshoot.proxy;
 
+import io.netty.handler.codec.http.HttpRequest;
+
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 
@@ -43,9 +45,10 @@ public interface MitmManager {
      * by issuing replacement certificates signed by the proxy's own
      * certificate.
      * </p>
-     * 
+     *
+     * @param httpRequest the HTTP CONNECT request that is being man-in-the-middled
      * @param serverSslSession the {@link SSLSession} that's been established with the server
      * @return the SSLEngine used to connect to the client
      */
-    SSLEngine clientSslEngineFor(SSLSession serverSslSession);
+    SSLEngine clientSslEngineFor(HttpRequest httpRequest, SSLSession serverSslSession);
 }

--- a/src/main/java/org/littleshoot/proxy/extras/SelfSignedMitmManager.java
+++ b/src/main/java/org/littleshoot/proxy/extras/SelfSignedMitmManager.java
@@ -1,5 +1,6 @@
 package org.littleshoot.proxy.extras;
 
+import io.netty.handler.codec.http.HttpRequest;
 import org.littleshoot.proxy.MitmManager;
 
 import javax.net.ssl.SSLEngine;
@@ -23,7 +24,7 @@ public class SelfSignedMitmManager implements MitmManager {
     }
 
     @Override
-    public SSLEngine clientSslEngineFor(SSLSession serverSslSession) {
+    public SSLEngine clientSslEngineFor(HttpRequest httpRequest, SSLSession serverSslSession) {
         return selfSignedSslEngineSource.newSslEngine();
     }
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -736,7 +736,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         protected Future<?> execute() {
             return clientConnection
                     .encrypt(proxyServer.getMitmManager()
-                            .clientSslEngineFor(sslEngine.getSession()), false)
+                            .clientSslEngineFor(initialRequest, sslEngine.getSession()), false)
                     .addListener(
                             new GenericFutureListener<Future<? super Channel>>() {
                                 @Override


### PR DESCRIPTION
This implements the discussion in Issue #290. I've added the initialRequest to the clientSslEngineFor method, so the SSL context for the client can impersonate based on the client's request.