### PR TITLE
Save proxy user identity in Channel Context after Proxy Authentication

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
+import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.commons.codec.binary.Base64;
@@ -89,6 +90,11 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * Used for case-insensitive comparisons when checking direct proxy request.
      */
     private static final Pattern HTTP_SCHEME = Pattern.compile("^http://.*", Pattern.CASE_INSENSITIVE);
+    
+    /**
+     * Context attribute key for username
+     */
+    private static final AttributeKey<String> ATTR_USERNAME = AttributeKey.valueOf("username");
 
     /**
      * Keep track of all ProxyToServerConnections by host+port.
@@ -973,6 +979,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         LOG.debug(authentication);
         request.headers().remove(HttpHeaders.Names.PROXY_AUTHORIZATION);
         authenticated.set(true);
+        
+        //Save username for filtering based on user
+        ctx.attr(ATTR_USERNAME).set(userName);
+        
         return false;
     }
 


### PR DESCRIPTION
After user authenticated to proxy, proxy-authorization header is removed from original message. This change can be useful to let creating different filters based on user in filter source.