### PR TITLE
Dependency updates in advance of 1.1.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <netty.version>4.0.35.Final</netty.version>
-        <slf4j.version>1.7.19</slf4j.version>
+        <netty.version>4.0.36.Final</netty.version>
+        <slf4j.version>1.7.21</slf4j.version>
     </properties>
 
     <organization>
@@ -84,7 +84,7 @@
         <profile>
             <id>netty-4.1</id>
             <properties>
-                <netty.version>4.1.0.CR4</netty.version>
+                <netty.version>4.1.0.Final</netty.version>
             </properties>
         </profile>
     </profiles>
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.0.44-beta</version>
+            <version>2.0.54-beta</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.4.1</version>
                 </plugin>
 
                 <plugin>
@@ -344,7 +344,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>2.5.3</version>
                 </plugin>
 
                 <plugin>
@@ -356,7 +356,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
+                    <version>3.0.0</version>
                 </plugin>
 
                 <plugin>
@@ -389,7 +389,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.5</version>
+                <version>1.6.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>
@@ -409,7 +409,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.5.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -442,7 +442,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.1</version>
+                <version>2.4.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
This PR contains some minor dependency updates in advance of the 1.1.0 release. The most important ones are the netty update to the latest 4.0, and the slf4j update. The remaining plugin and test-scoped dependencies don't affect functionality.

Since this is so minor, I'll go ahead and merge this quickly so we can get the 1.1.0 release out.