### PR TITLE
HTTP response status reason phrase shouldn't duplicate version+code.

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -79,7 +79,7 @@ import static org.littleshoot.proxy.impl.ConnectionState.NEGOTIATING_CONNECT;
  */
 public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     private static final HttpResponseStatus CONNECTION_ESTABLISHED = new HttpResponseStatus(
-            200, "HTTP/1.1 200 Connection established");
+            200, "Connection established");
     /**
      * Used for case-insensitive comparisons when parsing Connection header values.
      */


### PR DESCRIPTION
Fix a typo without functional influence, I think.