### PR TITLE
Not adding the erroneous Proxy-Connection header on CONNECT responses

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -484,7 +484,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             HttpResponse response = responseFor(HttpVersion.HTTP_1_1,
                     CONNECTION_ESTABLISHED);
             response.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
-            response.headers().set("Proxy-Connection", HttpHeaders.Values.KEEP_ALIVE);
             ProxyUtils.addVia(response, proxyServer.getProxyAlias());
             return writeToChannel(response);
         };


### PR DESCRIPTION
We don't add the Proxy-Connection header when we respond to clients, except when responding to an MITM'd CONNECT. That makes little sense, as the browser believes LittleProxy can't see the HTTP request at all. Additionally, the Proxy-Connection header is erroneous anyway, and LP actually removes it when it encounters it in ClientToProxyConnection.switchProxyConnectionHeader().

Arguably, the Via header also should not be added when responding to CONNECTs, or when MITMing in general. Perhaps we could handle that during the general ConnectionFlow refactoring.
