### PR TITLE
Added the AcceptHandler feature to the proxy.

### DIFF
--- a/src/main/java/org/littleshoot/proxy/AcceptHandler.java
+++ b/src/main/java/org/littleshoot/proxy/AcceptHandler.java
@@ -1,0 +1,23 @@
+package org.littleshoot.proxy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * <p>
+ * Interface to manage the bytes read the first time after a client
+ * connection has been accepted.
+ * </p>
+ */
+public interface AcceptHandler {
+
+    /**
+     * Process the bytes coming from the first read performed on the
+     * underlying channel after the connection has been accepted.
+     * @param bytes
+     *         the bytes read from the underlying channel
+     * @return the bytes that will be processed by the proxy
+     */
+    ByteBuf process(ChannelHandlerContext ctx, ByteBuf bytes);
+
+}

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -270,6 +270,17 @@ public interface HttpProxyServerBootstrap {
 
     /**
      * <p>
+     * Specify an {@link AcceptHandler} to manage the bytes read the first
+     * time after a client connection has been accepted.
+     * </p>
+     *
+     * @param acceptHandler
+     * @return
+     */
+    HttpProxyServerBootstrap withAcceptHandler(AcceptHandler acceptHandler);
+
+    /**
+     * <p>
      * Add an {@link ActivityTracker} for tracking activity in this proxy.
      * </p>
      * 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -697,6 +697,31 @@ abstract class ProxyConnection<I extends HttpObject> extends
     }
 
     /**
+     * Utility handler for monitoring byte streams on this connection.
+     */
+    @Sharable
+    protected abstract class ByteStreamMonitor extends
+            ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg)
+                throws Exception {
+            Object processedMsg = msg;
+
+            try {
+                if (msg instanceof ByteBuf) {
+                    processedMsg = processBytes(ctx, (ByteBuf) msg);
+                }
+            } catch (Throwable t) {
+                LOG.warn("Unable to call processBytes", t);
+            } finally {
+                super.channelRead(ctx, processedMsg);
+            }
+        }
+
+        protected abstract ByteBuf processBytes(ChannelHandlerContext ctx, ByteBuf bytes);
+    }
+
+    /**
      * Utility handler for monitoring requests read on this connection.
      */
     @Sharable


### PR DESCRIPTION
Using the withAcceptHandler() method on the proxy bootstrap is now
possible to get access to the byte stream of the first read performed
on the underlying channel after a connection has been accepted and
before the message is http-parsed inside the channel pipeline.

An implementation of the interface AcceptHandler can be able to read
and/or modify the first bytes sent by a client before they are parsed,
as well as close the connection if some requirements are not met
and so on.