### PR TITLE
Update to netty 4.0.42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <netty.version>4.0.36.Final</netty.version>
+        <netty.version>4.0.42.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <java.version>1.7</java.version>
     </properties>
@@ -85,7 +85,7 @@
         <profile>
             <id>netty-4.1</id>
             <properties>
-                <netty.version>4.1.0.Final</netty.version>
+                <netty.version>4.1.6.Final</netty.version>
             </properties>
         </profile>
     </profiles>
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.0.54-beta</version>
+            <version>2.3.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -114,9 +114,9 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
     private volatile int idleConnectionTimeout;
     private final HostResolver serverResolver;
     private volatile GlobalTrafficShapingHandler globalTrafficShapingHandler;
-    private int maxInitialLineLength;
-    private int maxHeaderSize;
-    private int maxChunkSize;
+    private final int maxInitialLineLength;
+    private final int maxHeaderSize;
+    private final int maxChunkSize;
 
     /**
      * The alias or pseudonym for this proxy, used when adding the Via header.


### PR DESCRIPTION
This PR updates to the latest netty, and updates the mockito test dependency. It also makes the new fields introduced in PR #324 final.

It's been a while since we've had a release, so I'm thinking about making these updates and pushing one out. Any thoughts?