### PR TITLE
Javadoc error fixes

### DIFF
--- a/src/main/java/org/littleshoot/proxy/HttpFilters.java
+++ b/src/main/java/org/littleshoot/proxy/HttpFilters.java
@@ -67,14 +67,13 @@ import java.net.InetSocketAddress;
  * <li>serverToProxyResponseReceived</li>
  * <li>proxyToClientResponse</li>
  * </ol>
- * </p>
  */
 public interface HttpFilters {
     /**
      * Filters requests on their way from the client to the proxy. To interrupt processing of this request and return a
      * response to the client immediately, return an HttpResponse here. Otherwise, return null to continue processing as
      * usual.
-     * <p/>
+     * <p>
      * <b>Important:</b> When returning a response, you must include a mechanism to allow the client to determine the length
      * of the message (see RFC 7230, section 3.3.3: https://tools.ietf.org/html/rfc7230#section-3.3.3 ). For messages that
      * may contain a body, you may do this by setting the Transfer-Encoding to chunked, setting an appropriate
@@ -91,7 +90,7 @@ public interface HttpFilters {
      * Filters requests on their way from the proxy to the server. To interrupt processing of this request and return a
      * response to the client immediately, return an HttpResponse here. Otherwise, return null to continue processing as
      * usual.
-     * <p/>
+     * <p>
      * <b>Important:</b> When returning a response, you must include a mechanism to allow the client to determine the length
      * of the message (see RFC 7230, section 3.3.3: https://tools.ietf.org/html/rfc7230#section-3.3.3 ). For messages that
      * may contain a body, you may do this by setting the Transfer-Encoding to chunked, setting an appropriate

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -263,7 +263,7 @@ public interface HttpProxyServerBootstrap {
     /**
      * Specify a custom {@link HostResolver} for resolving server addresses.
      * 
-     * @param resolver
+     * @param serverResolver
      * @return
      */
     HttpProxyServerBootstrap withServerResolver(HostResolver serverResolver);

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -399,7 +399,7 @@ public class ProxyUtils {
     /**
      * Returns true if the HTTP response from the server is expected to indicate its own message length/end-of-message. Returns false
      * if the server is expected to indicate the end of the HTTP entity by closing the connection.
-     * <p/>
+     * <p>
      * This method is based on the allowed message length indicators in the HTTP specification, section 4.4:
      * <pre>
          4.4 Message Length
@@ -463,7 +463,7 @@ public class ProxyUtils {
      *     Transfer-Encoding: chunked
      * </pre>
      * This method will return a list of three values: "gzip", "deflate", "chunked".
-     * <p/>
+     * <p>
      * Placing values on multiple header lines is allowed under certain circumstances
      * in RFC 2616 section 4.2, and in RFC 7230 section 3.2.2 quoted here:
      * <pre>

--- a/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ServerGroup.java
@@ -122,7 +122,7 @@ public class ServerGroup {
      * for the transport protocol if they have not yet been initialized. If the protocol has already been initialized,
      * this method returns immediately, without synchronization. If initialization is necessary, the initialization
      * process creates the acceptor and worker threads necessary to service requests to/from the proxy.
-     * <p/>
+     * <p>
      * This method is thread-safe; no external locking is necessary.
      *
      * @param protocol transport protocol to retrieve thread pools for
@@ -245,7 +245,7 @@ public class ServerGroup {
     /**
      * Retrieves the client-to-proxy acceptor thread pool for the specified protocol. Initializes the pool if it has not
      * yet been initialized.
-     * <p/>
+     * <p>
      * This method is thread-safe; no external locking is necessary.
      *
      * @param protocol transport protocol to retrieve the thread pool for
@@ -258,7 +258,7 @@ public class ServerGroup {
     /**
      * Retrieves the client-to-proxy acceptor worker pool for the specified protocol. Initializes the pool if it has not
      * yet been initialized.
-     * <p/>
+     * <p>
      * This method is thread-safe; no external locking is necessary.
      *
      * @param protocol transport protocol to retrieve the thread pool for
@@ -271,7 +271,7 @@ public class ServerGroup {
     /**
      * Retrieves the proxy-to-server worker thread pool for the specified protocol. Initializes the pool if it has not
      * yet been initialized.
-     * <p/>
+     * <p>
      * This method is thread-safe; no external locking is necessary.
      *
      * @param protocol transport protocol to retrieve the thread pool for


### PR DESCRIPTION
This fixes a few javadoc errors when using Java 8.

Since it's a doc-only PR, I'll go ahead and merge it.