### PR TITLE
Remove commons-io and commons-codec dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,8 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.3.1</version>
+            <!-- Only required when running as a standalone jar -->
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,18 +104,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.4</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>

--- a/src/main/java/org/littleshoot/proxy/extras/SelfSignedSslEngineSource.java
+++ b/src/main/java/org/littleshoot/proxy/extras/SelfSignedSslEngineSource.java
@@ -1,5 +1,17 @@
 package org.littleshoot.proxy.extras;
 
+import com.google.common.io.ByteStreams;
+import org.littleshoot.proxy.SslEngineSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -9,19 +21,6 @@ import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
-
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
-
-import org.apache.commons.io.IOUtils;
-import org.littleshoot.proxy.SslEngineSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Basic {@link SslEngineSource} for testing. The {@link SSLContext} uses
@@ -166,10 +165,13 @@ public class SelfSignedSslEngineSource implements SslEngineSource {
         try {
             final Process process = pb.start();
             final InputStream is = process.getInputStream();
-            final String data = IOUtils.toString(is);
-            LOG.info("Completed native call: '{}'\nResponse: '" + data + "'",
+
+            byte[] data = ByteStreams.toByteArray(is);
+            String dataAsString = new String(data);
+
+            LOG.info("Completed native call: '{}'\nResponse: '" + dataAsString + "'",
                     Arrays.asList(commands));
-            return data;
+            return dataAsString;
         } catch (final IOException e) {
             LOG.error("Error running commands: " + Arrays.asList(commands), e);
             return "";

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -1,5 +1,6 @@
 package org.littleshoot.proxy.impl;
 
+import com.google.common.io.BaseEncoding;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -23,7 +24,6 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.littleshoot.proxy.ActivityTracker;
 import org.littleshoot.proxy.FlowContext;
@@ -754,7 +754,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * descending ordering.
      * 
      * Regarding the Javadoc of {@link HttpObjectAggregator} it's needed to have
-     * the {@link HttpResponseEncoder} or {@link HttpRequestEncoder} before the
+     * the {@link HttpResponseEncoder} or {@link io.netty.handler.codec.http.HttpRequestEncoder} before the
      * {@link HttpObjectAggregator} in the {@link ChannelPipeline}.
      * 
      * @param pipeline
@@ -966,8 +966,9 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                 HttpHeaders.Names.PROXY_AUTHORIZATION);
         String fullValue = values.iterator().next();
         String value = StringUtils.substringAfter(fullValue, "Basic ").trim();
-        
-        byte[] decodedValue = Base64.decodeBase64(value.getBytes(Charset.forName("UTF-8")));
+
+        byte[] decodedValue = BaseEncoding.base64().decode(value);
+
         String decodedString = new String(decodedValue, Charset.forName("UTF-8"));
         
         String userName = StringUtils.substringBefore(decodedString, ":");

--- a/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/impl/DefaultHttpProxyServer.java
@@ -16,7 +16,6 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.udt.nio.NioUdtProvider;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 import io.netty.util.concurrent.GlobalEventExecutor;
-import org.apache.commons.io.IOUtils;
 import org.littleshoot.proxy.ActivityTracker;
 import org.littleshoot.proxy.ChainedProxyManager;
 import org.littleshoot.proxy.DefaultHostResolver;
@@ -170,14 +169,10 @@ public class DefaultHttpProxyServer implements HttpProxyServer {
         Properties props = new Properties();
 
         if (propsFile.isFile()) {
-            InputStream is = null;
-            try {
-                is = new FileInputStream(propsFile);
+            try (InputStream is = new FileInputStream(propsFile)) {
                 props.load(is);
             } catch (final IOException e) {
                 LOG.warn("Could not load props file?", e);
-            } finally {
-                IOUtils.closeQuietly(is);
             }
         }
 

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -9,7 +9,6 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.server.Server;
 import org.junit.After;
 import org.junit.Before;
@@ -99,14 +98,11 @@ public class HttpFilterTest {
 
         final InetSocketAddress isa = new InetSocketAddress("127.0.0.1", proxyServer.getListenAddress().getPort());
         while (true) {
-            final Socket sock = new Socket();
-            try {
+            try (Socket sock = new Socket()) {
                 sock.connect(isa);
                 break;
             } catch (final IOException e) {
                 // Keep trying.
-            } finally {
-                IOUtils.closeQuietly(sock);
             }
 
             try {


### PR DESCRIPTION
By using guava, built-in java functions, and try-with-resources (now that we're on Java 7), we can remove these two dependencies. Just two fewer dependencies we need to keep up-to-date.