### PR TITLE
add basic auth support to proxy chain

### DIFF
--- a/src/main/java/org/littleshoot/proxy/ChainedProxy.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxy.java
@@ -73,4 +73,23 @@ public interface ChainedProxy extends SslEngineSource {
      * Called to let us know that we were disconnected.
      */
     void disconnected();
+    
+    /**
+     * (Optional) user name which is send to the Chain Proxy using basic authentication. The user name
+     * is only send if the {@link #getBasicAuthPassword()} method provides a non <code>null</code>
+     * string.
+     * 
+     * @return The user name or <code>null</code> if no authentication to the Chain Proxy is
+     *         necessary.
+     */
+    String getBasicAuthUser();
+    
+    /**
+     * (Optional) user password which is send to the Chain Proxy using basic authentication. The
+     * password is only send if the {@link #getBasicAuthUser()} method provides a non
+     * <code>null</code> string.
+     * 
+     * @return The password or <code>null</code> if no authentication to the Chain Proxy is necessary.
+     */
+    String getBasicAuthPassword();
 }

--- a/src/main/java/org/littleshoot/proxy/ChainedProxyAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxyAdapter.java
@@ -61,4 +61,14 @@ public class ChainedProxyAdapter implements ChainedProxy {
     public SSLEngine newSslEngine(String peerHost, int peerPort) {
         return null;
     }
+
+    @Override
+    public String getBasicAuthUser() {
+        return null;
+    }
+
+    @Override
+    public String getBasicAuthPassword() {
+        return null;
+    }
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -1080,6 +1080,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             switchProxyConnectionHeader(headers);
             stripConnectionTokens(headers);
             stripHopByHopHeaders(headers);
+            addRemoteBasicAuthHeaders(headers);
             ProxyUtils.addVia(httpRequest, proxyServer.getProxyAlias());
         }
     }
@@ -1183,6 +1184,25 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         for (String headerName : headerNames) {
             if (ProxyUtils.shouldRemoveHopByHopHeader(headerName)) {
                 headers.remove(headerName);
+            }
+        }
+    }
+    
+    /**
+     * Add basic authentication header for the case that a chained proxy with basic authentication
+     * is available.
+     * 
+     * @param headers
+     *            The headers to modify
+     */
+    private void addRemoteBasicAuthHeaders(HttpHeaders headers) {
+        if (currentServerConnection.getChainedProxy() != null) {
+            String basicAuthUser = currentServerConnection.getChainedProxy().getBasicAuthUser();
+            String basicAuthPassword = currentServerConnection.getChainedProxy().getBasicAuthPassword();
+            if (basicAuthUser != null && basicAuthPassword != null) {
+                String basicAuthString = "Basic "
+                        + new String(Base64.encodeBase64((basicAuthUser + ":" + basicAuthPassword).getBytes()));
+                headers.add(HttpHeaders.Names.PROXY_AUTHORIZATION.toLowerCase(Locale.US), basicAuthString);
             }
         }
     }


### PR DESCRIPTION
I want to be able to create a proxy chain to a remote proxy which is not under my control and is configured to use http basic authentication. 

Here is the usage code for the changes I made.
```java
bootstrap.withChainProxyManager(new ChainedProxyManager() {

    @Override
    public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies) {
        chainedProxies.add(new ChainedProxyAdapter() {

            @Override
            public InetSocketAddress getChainedProxyAddress() {
                try {
                    return new InetSocketAddress(InetAddress.getByName(chainingProxyHost), chainingProxyPort);
                } catch (UnknownHostException uhe) {
                    throw new RuntimeException(uhe);
                }
            }

            @Override
            public String getBasicAuthUser() {
                return chainingProxyUser;
            }

            @Override
            public String getBasicAuthPassword() {
                return chainingProxyPass;
            }

        });
    }
});
```