### PR TITLE
Fix NPE when failing to decode response from server

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -482,7 +481,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
 
         protected Future<?> execute() {
             LOG.debug("Responding with CONNECT successful");
-            HttpResponse response = responseFor(HttpVersion.HTTP_1_1,
+            HttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1,
                     CONNECTION_ESTABLISHED);
             response.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
             ProxyUtils.addVia(response, proxyServer.getProxyAlias());
@@ -754,7 +753,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * descending ordering.
      * 
      * Regarding the Javadoc of {@link HttpObjectAggregator} it's needed to have
-     * the {@link HttpResponseEncoder} or {@link HttpRequestEncoder} before the
+     * the {@link HttpResponseEncoder} or {@link io.netty.handler.codec.http.HttpRequestEncoder} before the
      * {@link HttpObjectAggregator} in the {@link ChannelPipeline}.
      * 
      * @param pipeline
@@ -999,7 +998,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
                 + "credentials (e.g., bad password), or your\n"
                 + "browser doesn't understand how to supply\n"
                 + "the credentials required.</p>\n" + "</body></html>\n";
-        DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1,
+        FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED, body);
         HttpHeaders.setDate(response, new Date());
         response.headers().set("Proxy-Authenticate",
@@ -1201,7 +1200,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private boolean writeBadGateway(HttpRequest httpRequest) {
         String body = "Bad Gateway: " + httpRequest.getUri();
-        DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_GATEWAY, body);
+        FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_GATEWAY, body);
 
         if (ProxyUtils.isHEAD(httpRequest)) {
             // don't allow any body content in response to a HEAD request
@@ -1220,7 +1219,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private boolean writeBadRequest(HttpRequest httpRequest) {
         String body = "Bad Request to URI: " + httpRequest.getUri();
-        DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST, body);
+        FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST, body);
 
         if (ProxyUtils.isHEAD(httpRequest)) {
             // don't allow any body content in response to a HEAD request
@@ -1240,7 +1239,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private boolean writeGatewayTimeout(HttpRequest httpRequest) {
         String body = "Gateway Timeout";
-        DefaultFullHttpResponse response = responseFor(HttpVersion.HTTP_1_1,
+        FullHttpResponse response = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.GATEWAY_TIMEOUT, body);
 
         if (httpRequest != null && ProxyUtils.isHEAD(httpRequest)) {
@@ -1297,55 +1296,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         }
 
         return true;
-    }
-
-    /**
-     * Factory for {@link DefaultFullHttpResponse}s.
-     * 
-     * @param httpVersion
-     * @param status
-     * @param body
-     * @return
-     */
-    private DefaultFullHttpResponse responseFor(HttpVersion httpVersion,
-            HttpResponseStatus status, String body) {
-        byte[] bytes = body.getBytes(Charset.forName("UTF-8"));
-        ByteBuf content = Unpooled.copiedBuffer(bytes);
-        return responseFor(httpVersion, status, content, bytes.length);
-    }
-
-    /**
-     * Factory for {@link DefaultFullHttpResponse}s.
-     * 
-     * @param httpVersion
-     * @param status
-     * @param body
-     * @param contentLength
-     * @return
-     */
-    private DefaultFullHttpResponse responseFor(HttpVersion httpVersion,
-            HttpResponseStatus status, ByteBuf body, int contentLength) {
-        DefaultFullHttpResponse response = body != null ? new DefaultFullHttpResponse(
-                HttpVersion.HTTP_1_1, status, body)
-                : new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status);
-        if (body != null) {
-            response.headers().set(HttpHeaders.Names.CONTENT_LENGTH,
-                    contentLength);
-            response.headers().set("Content-Type", "text/html; charset=UTF-8");
-        }
-        return response;
-    }
-
-    /**
-     * Factory for {@link DefaultFullHttpResponse}s.
-     * 
-     * @param httpVersion
-     * @param status
-     * @return
-     */
-    private DefaultFullHttpResponse responseFor(HttpVersion httpVersion,
-            HttpResponseStatus status) {
-        return responseFor(httpVersion, status, (ByteBuf) null, 0);
     }
 
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -428,7 +428,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             // if this HttpResponse does not have any means of signaling the end of the message body other than closing
             // the connection, convert the message to a "Transfer-Encoding: chunked" HTTP response. This avoids the need
             // to close the client connection to indicate the end of the message. (Responses to HEAD requests "must be" empty.)
-            if (!ProxyUtils.isHead(currentHttpRequest) && !ProxyUtils.isResponseSelfTerminating(httpResponse)) {
+            if (!ProxyUtils.isHEAD(currentHttpRequest) && !ProxyUtils.isResponseSelfTerminating(httpResponse)) {
                 // if this is not a FullHttpResponse,  duplicate the HttpResponse from the server before sending it to
                 // the client. this allows us to set the Transfer-Encoding to chunked without interfering with netty's
                 // handling of the response from the server. if we modify the original HttpResponse from the server,

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -387,16 +387,6 @@ public class ProxyUtils {
     }
 
     /**
-     * Returns true if the request is an HTTP HEAD request.
-     *
-     * @param request HTTP request
-     * @return true if request is a HEAD, otherwise false
-     */
-    public static boolean isHead(HttpRequest request) {
-        return HttpMethod.HEAD.equals(request.getMethod());
-    }
-
-    /**
      * Returns true if the HTTP response from the server is expected to indicate its own message length/end-of-message. Returns false
      * if the server is expected to indicate the end of the HTTP entity by closing the connection.
      * <p>

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -4,15 +4,19 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.udt.nio.NioUdtProvider;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -21,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -574,5 +579,62 @@ public class ProxyUtils {
         } catch (NoClassDefFoundError e) {
             return false;
         }
+    }
+
+    /**
+     * Creates a new {@link FullHttpResponse} with the specified String as the body contents (encoded using UTF-8).
+     *
+     * @param httpVersion HTTP version of the response
+     * @param status HTTP status code
+     * @param body body to include in the FullHttpResponse; will be UTF-8 encoded
+     * @return new http response object
+     */
+    public static FullHttpResponse createFullHttpResponse(HttpVersion httpVersion,
+                                                          HttpResponseStatus status,
+                                                          String body) {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        ByteBuf content = Unpooled.copiedBuffer(bytes);
+
+        return createFullHttpResponse(httpVersion, status, "text/html; charset=utf-8", content, bytes.length);
+    }
+
+    /**
+     * Creates a new {@link FullHttpResponse} with no body content
+     *
+     * @param httpVersion HTTP version of the response
+     * @param status HTTP status code
+     * @return new http response object
+     */
+    public static FullHttpResponse createFullHttpResponse(HttpVersion httpVersion,
+                                                          HttpResponseStatus status) {
+        return createFullHttpResponse(httpVersion, status, null, null, 0);
+    }
+
+    /**
+     * Creates a new {@link FullHttpResponse} with the specified body.
+     *
+     * @param httpVersion HTTP version of the response
+     * @param status HTTP status code
+     * @param contentType the Content-Type of the body
+     * @param body body to include in the FullHttpResponse; if null
+     * @param contentLength number of bytes to send in the Content-Length header; should equal the number of bytes in the ByteBuf
+     * @return new http response object
+     */
+    public static FullHttpResponse createFullHttpResponse(HttpVersion httpVersion,
+                                                          HttpResponseStatus status,
+                                                          String contentType,
+                                                          ByteBuf body,
+                                                          int contentLength) {
+        DefaultFullHttpResponse response;
+
+        if (body != null) {
+            response = new DefaultFullHttpResponse(httpVersion, status, body);
+            response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, contentLength);
+            response.headers().set(HttpHeaders.Names.CONTENT_TYPE, contentType);
+        } else {
+            response = new DefaultFullHttpResponse(httpVersion, status);
+        }
+
+        return response;
     }
 }

--- a/src/test/java/org/littleshoot/proxy/test/ServerErrorTest.java
+++ b/src/test/java/org/littleshoot/proxy/test/ServerErrorTest.java
@@ -1,0 +1,94 @@
+package org.littleshoot.proxy.test;
+
+import org.junit.After;
+import org.junit.Test;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServerErrorTest {
+    private HttpProxyServer proxyServer;
+
+    @Test
+    public void testInvalidServerResponse() throws IOException {
+        proxyServer = DefaultHttpProxyServer.bootstrap()
+                .withPort(0)
+                .start();
+
+        // we have to create our own socket here, since any proper http server (jetty, mockserver, etc.) won't allow us to
+        // send invalid responses.
+        try (ServerSocket socket = createServerWithBadResponse()) {
+            org.apache.http.HttpResponse response = HttpClientUtil.performHttpGet("http://localhost:" + socket.getLocalPort(), proxyServer);
+
+            assertEquals("Expected to receive a 502 Bad Gateway after server responded with invalid response", 502, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (proxyServer != null) {
+            proxyServer.abort();
+        }
+    }
+
+    /**
+     * Creates a ServerSocket that will read an HTTP request and response with an invalid response.
+     * NOTE: the ServerSocket must be closed after the response is consumed.
+     */
+    private static ServerSocket createServerWithBadResponse() {
+        final ServerSocket serverSocket;
+        try {
+            serverSocket = new ServerSocket(0);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Runnable server = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Socket socket = serverSocket.accept();
+
+                    try (PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
+                         BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+                        while (!in.readLine().isEmpty()) {
+                            // read the request up to the double-CRLF
+                        }
+
+                        // write a a response with an invalid HTTP version
+                        out.write("HTTP/1.12312312312312411231231231 200 OK\r\n" +
+                                "Connection: close\r\n" +
+                                "Content-Length: 0\r\n" +
+                                "\r\n");
+                        out.flush();
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        // start the server in a separate thread
+        Thread serverThread = new Thread(server);
+        serverThread.setDaemon(true);
+        serverThread.start();
+
+        // wait for the server to start
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        return serverSocket;
+    }
+
+}


### PR DESCRIPTION
This PR should fix issue #303. It does two things:
- Keeps track of the current request in ProxyToServerConnection as soon as it is sent to the server. Removes the "queue" of current requests and the need to "pop" from the queue at some point while processing the response from the server. The code always assumed there would be only one request per connection, so having a stack of requests is unnecessary.
- When netty fails to decode a response from the server, this will "substitute" a new 502 Bad Gateway response and send that to the client, closing the connection to the server in the process. This is the most sensible thing we can do, since a decoder failure means the response is too malformed to make any sense of.

The current code already assumes there is one request outstanding per connection at a time. This is sensible in HTTP 1.1 (pipelining notwithstanding, though that's rarely used), but will need to change when we support HTTP/2.