### PR TITLE
Update readme for 1.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can embed LittleProxy in your own projects through Maven with the following:
     <dependency>
         <groupId>org.littleshoot</groupId>
         <artifactId>littleproxy</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </dependency>
 ```
 


### PR DESCRIPTION
Just realized I forgot to bump the version number in the readme after the last release. I'll go ahead and merge this right away.