### PR TITLE
Update netty version to avoid false positive leak detections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <netty.version>4.0.42.Final</netty.version>
+        <netty.version>4.0.44.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <java.version>1.7</java.version>
     </properties>
@@ -177,7 +177,7 @@
         <profile>
             <id>netty-4.1</id>
             <properties>
-                <netty.version>4.1.6.Final</netty.version>
+                <netty.version>4.1.8.Final</netty.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
This PR updates netty to 4.0.44/4.1.8. There have been a few reports of the netty leak detector reporting leaks when using LP (#348, #313). I suspect/hope those leaks were actually false positives caused by a netty bug that has since been [fixed](https://github.com/netty/netty/pull/6103) in 4.0.43/4.1.7. This PR will get folks on the latest netty, so we can at least weed out those false positives.