### PR TITLE
Repeated TimeOut response fix

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -409,7 +409,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
     @Override
     protected void timedOut() {
         super.timedOut();
-        clientConnection.timedOut();
+        clientConnection.timedOut(this);
     }
 
     @Override

--- a/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
+++ b/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
@@ -85,7 +85,7 @@ public class KeepAliveTest {
         this.socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
 
         // construct the basic request: METHOD + URI + HTTP version + CRLF (to indicate the end of the request)
-        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\r\n"
                 + "\r\n";
 
         // send the same request twice over the same connection
@@ -129,7 +129,7 @@ public class KeepAliveTest {
         this.socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
 
         // construct the basic request: METHOD + URI + HTTP version + CRLF (to indicate the end of the request)
-        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\r\n"
                 + "\r\n";
 
         // send the same request twice over the same connection
@@ -172,7 +172,7 @@ public class KeepAliveTest {
 
         socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
 
-        String badGatewayGet = "GET http://localhost:0/success HTTP/1.1\n"
+        String badGatewayGet = "GET http://localhost:0/success HTTP/1.1\r\n"
                 + "\r\n";
 
         // send the same request twice over the same connection
@@ -206,35 +206,27 @@ public class KeepAliveTest {
                         .withBody("success"));
 
         this.proxyServer = DefaultHttpProxyServer.bootstrap()
-                .withIdleConnectionTimeout(3)
+                .withIdleConnectionTimeout(2)
                 .withPort(0)
                 .start();
 
         socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
 
-        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\r\n"
                 + "\r\n";
 
         // send the same request twice over the same connection
         for (int i = 1; i <= 2; i++) {
             SocketClientUtil.writeStringToSocket(successfulGet, socket);
 
-            // wait a bit to allow the proxy server to respond
-            Thread.sleep(3500);
-
             String response = SocketClientUtil.readStringFromSocket(socket);
 
+	        // match the whole response to make sure that the it is not repeated
             assertThat("The response is repeated:", response, is("HTTP/1.1 504 Gateway Timeout\r\n" +
                     "Content-Length: 15\r\n" +
                     "Content-Type: text/html; charset=utf-8\r\n" +
                     "\r\n" +
-                    "Gateway TimeoutHTTP/1.1 504 Gateway Timeout\r\n" +
-                    "Content-Length: 15\r\n" +
-                    "Content-Type: text/html; charset=utf-8\r\n" +
-                    "\r\n" +
                     "Gateway Timeout"));
-
-            assertThat("Expected to receive an HTTP 200 from the server (iteration: " + i + ")", response, startsWith("HTTP/1.1 504 Gateway Timeout"));
         }
 
         assertTrue("Expected connection to proxy server to be open and readable", SocketClientUtil.isSocketReadyToRead(socket));
@@ -279,7 +271,7 @@ public class KeepAliveTest {
 
         socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
 
-        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\r\n"
                 + "\r\n";
 
         // send the same request twice over the same connection
@@ -338,7 +330,7 @@ public class KeepAliveTest {
 
         socket = SocketClientUtil.getSocketToProxyServer(proxyServer);
 
-        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\n"
+        String successfulGet = "GET http://localhost:" + mockServerPort + "/success HTTP/1.1\r\n"
                 + "\r\n";
 
         // only send this request once, since we expect the short circuit response to close the connection

--- a/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
+++ b/src/test/java/org/littleshoot/proxy/KeepAliveTest.java
@@ -21,9 +21,7 @@ import java.net.Socket;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -225,6 +223,16 @@ public class KeepAliveTest {
             Thread.sleep(3500);
 
             String response = SocketClientUtil.readStringFromSocket(socket);
+
+            assertThat("The response is repeated:", response, is("HTTP/1.1 504 Gateway Timeout\r\n" +
+                    "Content-Length: 15\r\n" +
+                    "Content-Type: text/html; charset=utf-8\r\n" +
+                    "\r\n" +
+                    "Gateway TimeoutHTTP/1.1 504 Gateway Timeout\r\n" +
+                    "Content-Length: 15\r\n" +
+                    "Content-Type: text/html; charset=utf-8\r\n" +
+                    "\r\n" +
+                    "Gateway Timeout"));
 
             assertThat("Expected to receive an HTTP 200 from the server (iteration: " + i + ")", response, startsWith("HTTP/1.1 504 Gateway Timeout"));
         }

--- a/src/test/java/org/littleshoot/proxy/TimeoutTest.java
+++ b/src/test/java/org/littleshoot/proxy/TimeoutTest.java
@@ -20,8 +20,8 @@ import java.net.Socket;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -132,9 +132,7 @@ public class TimeoutTest {
         // wait a bit to allow the proxy server to respond
         Thread.sleep(1500);
 
-        // the proxy should return an HTTP 504 due to the timeout
-        String response = SocketClientUtil.readStringFromSocket(socket);
-        assertThat("Expected to receive an HTTP 504 Gateway Timeout from the server", response, startsWith("HTTP/1.1 504"));
+        assertFalse("Client to proxy connection should be closed", SocketClientUtil.isSocketReadyToRead(socket));
 
         socket.close();
     }

--- a/src/test/java/org/littleshoot/proxy/test/SocketClientUtil.java
+++ b/src/test/java/org/littleshoot/proxy/test/SocketClientUtil.java
@@ -61,10 +61,10 @@ public class SocketClientUtil {
     public static boolean isSocketReadyToWrite(Socket socket) throws IOException {
         OutputStream out = socket.getOutputStream();
         try {
-            out.write(0);
-            out.flush();
-            out.write(0);
-            out.flush();
+            for(int i = 0; i < 500; ++i) {
+                out.write(0);
+                out.flush();
+            }
         } catch (SocketException e) {
             return false;
         }


### PR DESCRIPTION
This fixes repeated response to HTTP 1.1 request that has not been processed by server in configured time out period (Bug is demonstrated here:  https://github.com/luleyl/LittleProxy/commit/55fd04d744e3db54b5a37206f682affb5465f56a).
