### PR TITLE
Fix memory leak on initial requests with HttpObjectAggregator

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -930,6 +930,13 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         } else {
             LOG.debug("Dropping initial request: {}", initialRequest);
         }
+
+        // we're now done with the initialRequest: it's either been forwarded to the upstream server (HTTP requests), or
+        // completely dropped (HTTPS CONNECTs). if the initialRequest is reference counted (typically because the HttpObjectAggregator is in
+        // the pipeline to generate FullHttpRequests), we need to manually release it to avoid a memory leak.
+        if (initialRequest instanceof ReferenceCounted) {
+            ((ReferenceCounted)initialRequest).release();
+        }
     }
 
     /**


### PR DESCRIPTION
This PR should fix issue #348. The change is very simple: initial HttpRequests are released if they are ReferenceCounted. However, the reasoning is complicated and requires a non-trivial understanding of netty reference counting, so here's a more detailed explanation of what's happening:
 
When `HttpObjectAggregator` is in the pipeline, it generates `ReferenceCounted` `FullHttpRequest`s (since they have content as well as the request headers). Whereas, when `HttpObjectAggregator` is not in the pipeline, the `HttpRequest` does not contain body content and therefore is not `ReferenceCounted`.

When the `ProxyToServerConnection#write()` method is called, it always increments ReferenceCounted objects, since netty will automatically decrement them when they are written to the server (and we want to keep them around, since our ClientToProxyConnection will also try to clean them up).  Generally this works fine, even for FullHttpRequests, but it breaks when dealing with the initial request.

For initial HTTP messages, which _are_ eventually written to the server, the `ProxyToServerConnection#write()` method is called twice: first when the server is disconnected, and then again after the connection is complete. This causes the `ReferenceCounted` object to be `.retain()`ed twice, but only released by netty once (when it is actually written to the server).

For initial HTTPS messages (always a CONNECT), which _are not_ written to the server at all, they are only `.retain()`ed once, when the server is disconnected, then "dropped", since the CONNECT is never written to the upstream server. But since the FullHttpRequest was already retained by the write() method, it must be manually released.