### PR TITLE
Updated guava, dnsjava, slf4j, commons-lang, and test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
         <netty.version>4.0.44.Final</netty.version>
-        <slf4j.version>1.7.21</slf4j.version>
+        <slf4j.version>1.7.24</slf4j.version>
         <java.version>1.7</java.version>
     </properties>
 
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>20.0</version>
         </dependency>
 
         <dependency>
@@ -200,7 +200,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.5</version>
         </dependency>
 
         <dependency>
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.3.0</version>
+            <version>2.7.12</version>
             <scope>test</scope>
         </dependency>
 
@@ -274,7 +274,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.3</version>
             <scope>test</scope>
         </dependency>
 
@@ -305,7 +305,7 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>2.1.7</version>
+            <version>2.1.8</version>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
Given the recent memory leak fix and netty fixes (among others), we should probably plan on a release fairly soon. To that end, this PR updates various dependencies to the latest versions supported on Java 7.