### PR TITLE
Proxy Authorization

### DIFF
--- a/src/main/java/org/littleshoot/proxy/BasicProxyAuthenticator.java
+++ b/src/main/java/org/littleshoot/proxy/BasicProxyAuthenticator.java
@@ -1,0 +1,33 @@
+package org.littleshoot.proxy;
+
+import com.google.common.io.BaseEncoding;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.charset.Charset;
+
+/**
+ *
+ */
+public class BasicProxyAuthenticator {
+
+  private final ProxyAuthenticator proxyAuthenticator;
+
+  public BasicProxyAuthenticator(ProxyAuthenticator proxyAuthenticator) {
+    this.proxyAuthenticator = proxyAuthenticator;
+  }
+
+  public boolean authenticate(String proxyAuthorizationHeaderValue) {
+    String value = StringUtils.substringAfter(proxyAuthorizationHeaderValue, "Basic ").trim();
+
+    byte[] decodedValue = BaseEncoding.base64().decode(value);
+
+    String decodedString = new String(decodedValue, Charset.forName("UTF-8"));
+
+    String userName = StringUtils.substringBefore(decodedString, ":");
+    String password = StringUtils.substringAfter(decodedString, ":");
+
+    return proxyAuthenticator.authenticate(userName, password);
+  }
+
+}

--- a/src/main/java/org/littleshoot/proxy/ProxyAuthenticator.java
+++ b/src/main/java/org/littleshoot/proxy/ProxyAuthenticator.java
@@ -5,6 +5,17 @@ package org.littleshoot.proxy;
  * the basis of a username and password.
  */
 public interface ProxyAuthenticator {
+
+    /**
+     * Authenticates the user using the specified proxy authorization header.
+     *
+     * @param proxyAuthorizationHeaderValue
+     *            The proxy authorization header value.
+     * @return <code>true</code> if the credential is acceptable, otherwise
+     *         <code>false</code>.
+     */
+    boolean authenticate(String proxyAuthorizationHeaderValue);
+
     /**
      * Authenticates the user using the specified userName and password.
      * 
@@ -14,7 +25,10 @@ public interface ProxyAuthenticator {
      *            The password.
      * @return <code>true</code> if the credentials are acceptable, otherwise
      *         <code>false</code>.
+     * @deprecated Use BasicProxyAuthenticator.authenticate to authenticate Basic authorization
+     * requests.
      */
+    @Deprecated
     boolean authenticate(String userName, String password);
     
     /**

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -982,15 +982,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         List<String> values = request.headers().getAll(
                 HttpHeaders.Names.PROXY_AUTHORIZATION);
         String fullValue = values.iterator().next();
-        String value = StringUtils.substringAfter(fullValue, "Basic ").trim();
-
-        byte[] decodedValue = BaseEncoding.base64().decode(value);
-
-        String decodedString = new String(decodedValue, Charset.forName("UTF-8"));
-        
-        String userName = StringUtils.substringBefore(decodedString, ":");
-        String password = StringUtils.substringAfter(decodedString, ":");
-        if (!authenticator.authenticate(userName, password)) {
+        if (!authenticator.authenticate(fullValue)) {
             writeAuthenticationRequired(authenticator.getRealm());
             return true;
         }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -930,6 +930,13 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         } else {
             LOG.debug("Dropping initial request: {}", initialRequest);
         }
+
+        // we're now done with the initialRequest: it's either been forwarded to the upstream server (HTTP requests), or
+        // completely dropped (HTTPS CONNECTs). if the initialRequest is reference counted (typically because the HttpObjectAggregator is in
+        // the pipeline to generate FullHttpRequests), we need to manually release it to avoid a memory leak.
+        if (initialRequest instanceof ReferenceCounted) {
+            ((ReferenceCounted)initialRequest).release();
+        }
     }
 
     /**

--- a/src/test/java/org/littleshoot/proxy/MITMUsernamePasswordAuthenticatingProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MITMUsernamePasswordAuthenticatingProxyTest.java
@@ -22,4 +22,5 @@ public class MITMUsernamePasswordAuthenticatingProxyTest extends
     protected boolean isMITM() {
         return true;
     }
+
 }

--- a/src/test/java/org/littleshoot/proxy/UsernamePasswordAuthenticatingProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/UsernamePasswordAuthenticatingProxyTest.java
@@ -24,6 +24,11 @@ public class UsernamePasswordAuthenticatingProxyTest extends BaseProxyTest
     }
 
     @Override
+    public boolean authenticate(String proxyAuthorizationHeaderValue) {
+        return new BasicProxyAuthenticator(this).authenticate(proxyAuthorizationHeaderValue);
+    }
+
+    @Override
     public boolean authenticate(String userName, String password) {
         return getUsername().equals(userName) && getPassword().equals(password);
     }


### PR DESCRIPTION
Allows us to customize the authentication process. 

This is a breaking change that adds a new method to the ProxyAuthenticator interface.

We should change this

- `ProxyAuthenticator` - should only have the `authenticate(String)` method.
- `BasicProxyAuthenticator` - should have the `authenticate(String, String)` method.

The upgrade path should be for existing implementations to move to implementing `BasicProxyAuthenticator` instead of `Authenticator`