### PR TITLE
Update dependencies and replace deprecated guava usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <netty.version>4.0.44.Final</netty.version>
-        <slf4j.version>1.7.24</slf4j.version>
+        <netty.version>4.0.49.Final</netty.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <java.version>1.7</java.version>
     </properties>
 
@@ -177,7 +177,7 @@
         <profile>
             <id>netty-4.1</id>
             <properties>
-                <netty.version>4.1.8.Final</netty.version>
+                <netty.version>4.1.13.Final</netty.version>
             </properties>
         </profile>
     </profiles>
@@ -186,7 +186,9 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <!-- The -android version is the "official" non-Java 8 release of guava. Use the standard guava release once
+                 LP drops support for Java 7. -->
+            <version>22.0-android</version>
         </dependency>
 
         <dependency>
@@ -481,7 +483,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -572,7 +572,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                             .serverSslEngine()));
                 } else {
                     connectionFlow.then(serverConnection.EncryptChannel(proxyServer.getMitmManager()
-                            .serverSslEngine(parsedHostAndPort.getHostText(), parsedHostAndPort.getPort())));
+                            .serverSslEngine(parsedHostAndPort.getHost(), parsedHostAndPort.getPort())));
                 }
 
             	connectionFlow
@@ -958,7 +958,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             throw new UnknownHostException(hostAndPort);
         }
 
-        String host = parsedHostAndPort.getHostText();
+        String host = parsedHostAndPort.getHost();
         int port = parsedHostAndPort.getPortOrDefault(80);
 
         return proxyServer.getServerResolver().resolve(host, port);


### PR DESCRIPTION
This PR replaces the usage of guava's HostAndPort.getHostText() with .getHost(). Guava deprecated .getHostText() in 20 (Oct 2016), and removed it completely from 22 (May 2017). As a result, nobody using guava 22 can use LittleProxy.

This PR also bumps a few other dependency versions, including netty.