### PR TITLE
Add option for managing proxy authentication manually 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.littleshoot</groupId>
     <artifactId>littleproxy</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
     <name>LittleProxy</name>
     <description>
         LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.
@@ -53,6 +53,7 @@
         <tag>HEAD</tag>
     </scm>
 
+    <!--
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -62,6 +63,15 @@
         <repository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+    -->
+
+    <distributionManagement>
+        <repository>
+            <id>qoe-snapshots</id>
+            <name>QoE Snapshots</name>
+            <url>https://nexus.insight-performance.com/content/repositories/qoe-snapshots/</url>
         </repository>
     </distributionManagement>
 
@@ -183,10 +193,11 @@
     </profiles>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>24.1-jre</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServer.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServer.java
@@ -22,6 +22,11 @@ public interface HttpProxyServer {
     void setConnectTimeout(int connectTimeoutMs);
 
     /**
+     * Returns if the upstream proxy authentication is set to manual
+     */
+    Boolean isManualUpstreamProxyAuth();
+
+    /**
      * <p>
      * Clone the existing server, with a port 1 higher and everything else the
      * same. If the proxy was started with port 0 (JVM-assigned port), the cloned proxy will also use a JVM-assigned

--- a/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
+++ b/src/main/java/org/littleshoot/proxy/HttpProxyServerBootstrap.java
@@ -84,6 +84,22 @@ public interface HttpProxyServerBootstrap {
     HttpProxyServerBootstrap withAllowLocalOnly(boolean allowLocalOnly);
 
     /**
+     * <p>
+     * Specify whether or not allow upstream proxy manual authentication (Robot Framework, OpenCV...)
+     * </p>
+     *
+     * <p>
+     * Default = false
+     * </p>
+     */
+    void withManualUpstreamProxyAuth();
+
+    /**
+     * Returns if the upstream proxy authentication is set to manual
+     */
+    Boolean isManualUpstreamProxyAuth();
+
+    /**
      * This method has no effect and will be removed in a future release.
      * @deprecated use {@link #withNetworkInterface(InetSocketAddress)} to avoid listening on all local addresses
      */
@@ -117,7 +133,7 @@ public interface HttpProxyServerBootstrap {
      * Specify whether or not to authenticate inbound SSL clients (only applies
      * if {@link #withSslEngineSource(SslEngineSource)} has been set).
      * </p>
-     * 
+     *
      * <p>
      * Default = true
      * </p>

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -588,8 +588,6 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      * ultimate endpoint directly.</li>
      * <li>If the server was the ultimate endpoint, we return a 502 Bad Gateway
      * to the client.</li>
-     * <li>If the response status is a 407 (Proxy authentication) and manual
-     * proxy authentication is enabled, continue to normal flow</li>
      * </ol>
      * 
      * @param serverConnection

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -848,6 +848,12 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private boolean shouldCloseClientConnection(HttpRequest req,
             HttpResponse res, HttpObject httpObject) {
+        // In case of manual proxy authentication, we need to close the request to let the browser resend a request with
+        // the authentication informations
+        if (res.getStatus().code() == 407 && proxyServer.isManualUpstreamProxyAuth()) {
+            LOG.debug("Closing client connection since response is 407", res);
+            return true;
+        }
         if (ProxyUtils.isChunked(res)) {
             // If the response is chunked, we want to return false unless it's
             // the last chunk. If it is the last chunk, then we want to pass

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionState.java
@@ -28,6 +28,11 @@ enum ConnectionState {
     AWAITING_PROXY_AUTHENTICATION,
 
     /**
+     * Connected but waiting for proxy manual authentication.
+     */
+    AWAITING_PROXY_MANUAL_AUTH,
+
+    /**
      * Connected and awaiting initial message (e.g. HttpRequest or
      * HttpResponse).
      */

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -159,6 +159,9 @@ abstract class ProxyConnection<I extends HttpObject> extends
                 // to require authentication.
             }
             break;
+        case AWAITING_PROXY_MANUAL_AUTH:
+            LOG.warn("Proxy authentication required. You need to manage authentication manually");
+            break;
         case CONNECTING:
             LOG.warn("Attempted to read from connection that's in the process of connecting.  This shouldn't happen.");
             break;
@@ -455,7 +458,7 @@ abstract class ProxyConnection<I extends HttpObject> extends
      * Disconnects. This will wait for pending writes to be flushed before
      * disconnecting.
      * 
-     * @return Future<Void> for when we're done disconnecting. If we weren't
+     * @return for when we're done disconnecting. If we weren't
      *         connected, this returns null.
      */
     Future<Void> disconnect() {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -559,7 +559,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                             .serverSslEngine()));
                 } else {
                     connectionFlow.then(serverConnection.EncryptChannel(proxyServer.getMitmManager()
-                            .serverSslEngine(parsedHostAndPort.getHostText(), parsedHostAndPort.getPort())));
+                            .serverSslEngine(parsedHostAndPort.getHost(), parsedHostAndPort.getPort())));
                 }
 
             	connectionFlow
@@ -1006,7 +1006,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             throw new UnknownHostException(hostAndPort);
         }
 
-        String host = parsedHostAndPort.getHostText();
+        String host = parsedHostAndPort.getHost();
         int port = parsedHostAndPort.getPortOrDefault(80);
 
         return proxyServer.getServerResolver().resolve(host, port);

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -436,7 +436,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         }
         // This can happen if we couldn't make the initial connection due
         // to something like an unresolved address, for example, or a timeout.
-        // There will not have been be any requeaaaaaaasts written on an unopened
+        // There will not have been be any requests written on an unopened
         // connection, so there should not be any further action to take here.
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -13,20 +13,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.udt.nio.NioUdtProvider;
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpMessage;
-import io.netty.handler.codec.http.HttpObject;
-import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpRequestEncoder;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseDecoder;
-import io.netty.handler.codec.http.HttpResponseEncoder;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.*;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 import io.netty.util.ReferenceCounted;
@@ -41,22 +28,20 @@ import org.littleshoot.proxy.HttpFilters;
 import org.littleshoot.proxy.MitmManager;
 import org.littleshoot.proxy.TransportProtocol;
 import org.littleshoot.proxy.UnknownTransportProtocolException;
+import sun.rmi.runtime.Log;
 
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Date;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 
-import static org.littleshoot.proxy.impl.ConnectionState.AWAITING_CHUNK;
-import static org.littleshoot.proxy.impl.ConnectionState.AWAITING_CONNECT_OK;
-import static org.littleshoot.proxy.impl.ConnectionState.AWAITING_INITIAL;
-import static org.littleshoot.proxy.impl.ConnectionState.CONNECTING;
-import static org.littleshoot.proxy.impl.ConnectionState.DISCONNECTED;
-import static org.littleshoot.proxy.impl.ConnectionState.HANDSHAKING;
+import static org.littleshoot.proxy.impl.ConnectionState.*;
 
 /**
  * <p>
@@ -157,8 +142,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             GlobalTrafficShapingHandler globalTrafficShapingHandler)
             throws UnknownHostException {
         Queue<ChainedProxy> chainedProxies = new ConcurrentLinkedQueue<ChainedProxy>();
+
         ChainedProxyManager chainedProxyManager = proxyServer
                 .getChainProxyManager();
+
         if (chainedProxyManager != null) {
             chainedProxyManager.lookupChainedProxies(initialHttpRequest,
                     chainedProxies);
@@ -449,7 +436,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         }
         // This can happen if we couldn't make the initial connection due
         // to something like an unresolved address, for example, or a timeout.
-        // There will not have been be any requests written on an unopened
+        // There will not have been be any requeaaaaaaasts written on an unopened
         // connection, so there should not be any further action to take here.
     }
 
@@ -679,12 +666,36 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         void read(ConnectionFlow flow, Object msg) {
             // Here we're handling the response from a chained proxy to our
             // earlier CONNECT request
+            // If explicitly asked let Proxy Authentication made by user (Popup) => 407
             boolean connectOk = false;
             if (msg instanceof HttpResponse) {
                 HttpResponse httpResponse = (HttpResponse) msg;
                 int statusCode = httpResponse.getStatus().code();
-                if (statusCode >= 200 && statusCode <= 299) {
+                if (statusCode >= 200 && statusCode <= 299)
                     connectOk = true;
+                else if (statusCode == 407) {
+                    if (proxyServer.isManualUpstreamProxyAuth()) {
+                        LOG.warn("Manual upstream proxy authentication is enable and we are receiving a 407 response," +
+                                "be prepared to process the authentication popup");
+                        currentHttpRequest = initialRequest;
+                        String body = "<!DOCTYPE HTML \"-//IETF//DTD HTML 2.0//EN\">\n"
+                                + "<html><head>\n"
+                                + "<title>407 Proxy Authentication Required</title>\n"
+                                + "</head><body>\n"
+                                + "<h1>Proxy Authentication Required</h1>\n"
+                                + "<p>This server could not verify that you\n"
+                                + "are authorized to access the document\n"
+                                + "requested.  Either you supplied the wrong\n"
+                                + "credentials (e.g., bad password), or your\n"
+                                + "browser doesn't understand how to supply\n"
+                                + "the credentials required.</p>\n" + "</body></html>\n";
+                        FullHttpResponse fullHttpResponse = ProxyUtils.createFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED, body);
+                        for ( Map.Entry<String, String> entrie : httpResponse.headers().entries() )
+                            fullHttpResponse.headers().set(entrie.getKey(), entrie.getValue());
+                        rememberCurrentResponse(fullHttpResponse);
+                        respondWith(fullHttpResponse);
+                        // Request failed - Cause of Proxy not yet authenticate
+                    }
                 }
             }
             if (connectOk) {

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyUtils.java
@@ -325,7 +325,7 @@ public class ProxyUtils {
     public static int extractInt(final Properties props, final String key, int defaultValue) {
         final String readThrottleString = props.getProperty(key);
         if (StringUtils.isNotBlank(readThrottleString) &&
-            NumberUtils.isNumber(readThrottleString)) {
+            NumberUtils.isCreatable(readThrottleString)) {
             return Integer.parseInt(readThrottleString);
         }
         return defaultValue;


### PR DESCRIPTION
We use browserMob Proxy (which includes Little Proxy) with selenium to test plenty of websites. But in many cases, we need to manage Upstream Proxies with others authentications than "Basic".
So Little Proxy  would have to let us handle ourselves the authentications window.