### PR TITLE
Fix fail(null) of chained proxy

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -690,7 +690,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
             if (connectOk) {
                 flow.advance();
             } else {
-                flow.fail();
+                flow.fail(new Error(msg.toString()));
             }
         }
     };


### PR DESCRIPTION
This PR fixes a corner scenario when the chained proxy doesn't return with 20x response and returns the error message.