### PR TITLE
adamfisk#337 - SNI headers not being sent for outbound proxies.

### DIFF
--- a/src/test/java/org/littleshoot/proxy/BadClientAuthenticationTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BadClientAuthenticationTCPChainedProxyTest.java
@@ -47,6 +47,11 @@ public class BadClientAuthenticationTCPChainedProxyTest extends
             public SSLEngine newSslEngine() {
                 return clientSslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return clientSslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/BadServerAuthenticationTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BadServerAuthenticationTCPChainedProxyTest.java
@@ -47,6 +47,11 @@ public class BadServerAuthenticationTCPChainedProxyTest extends
             public SSLEngine newSslEngine() {
                 return clientSslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return clientSslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackToOtherChainedProxyDueToSSLTest.java
+++ b/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackToOtherChainedProxyDueToSSLTest.java
@@ -41,6 +41,11 @@ public class ChainedProxyWithFallbackToOtherChainedProxyDueToSSLTest extends
                     public SSLEngine newSslEngine() {
                         return serverSslEngineSource.newSslEngine();
                     }
+
+                    @Override
+                    public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                        return serverSslEngineSource.newSslEngine(peerHost, peerPort);
+                    }
                 });
             }
         };

--- a/src/test/java/org/littleshoot/proxy/ClientAuthenticationNotRequiredTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/ClientAuthenticationNotRequiredTCPChainedProxyTest.java
@@ -43,6 +43,11 @@ public class ClientAuthenticationNotRequiredTCPChainedProxyTest extends
             public SSLEngine newSslEngine() {
                 return clientSslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return clientSslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/EncryptedTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/EncryptedTCPChainedProxyTest.java
@@ -34,6 +34,11 @@ public class EncryptedTCPChainedProxyTest extends BaseChainedProxyTest {
             public SSLEngine newSslEngine() {
                 return sslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return sslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/EncryptedUDTChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/EncryptedUDTChainedProxyTest.java
@@ -34,6 +34,11 @@ public class EncryptedUDTChainedProxyTest extends BaseChainedProxyTest {
             public SSLEngine newSslEngine() {
                 return sslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return sslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -633,6 +633,11 @@ public class HttpFilterTest {
                                 // use the same "bad" keystore as BadServerAuthenticationTCPChainedProxyTest
                                 return new SelfSignedSslEngineSource("chain_proxy_keystore_2.jks").newSslEngine();
                             }
+
+                            @Override
+                            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                                return new SelfSignedSslEngineSource("chain_proxy_keystore_2.jks").newSslEngine(peerHost, peerPort);
+                            }
                         });
                     }
                 })

--- a/src/test/java/org/littleshoot/proxy/MitmWithBadClientAuthenticationTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithBadClientAuthenticationTCPChainedProxyTest.java
@@ -48,6 +48,11 @@ public class MitmWithBadClientAuthenticationTCPChainedProxyTest extends
             public SSLEngine newSslEngine() {
                 return clientSslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return clientSslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/MitmWithBadServerAuthenticationTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithBadServerAuthenticationTCPChainedProxyTest.java
@@ -48,6 +48,11 @@ public class MitmWithBadServerAuthenticationTCPChainedProxyTest extends
             public SSLEngine newSslEngine() {
                 return clientSslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return clientSslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/MitmWithClientAuthenticationNotRequiredTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithClientAuthenticationNotRequiredTCPChainedProxyTest.java
@@ -43,6 +43,11 @@ public class MitmWithClientAuthenticationNotRequiredTCPChainedProxyTest extends
             public SSLEngine newSslEngine() {
                 return clientSslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return clientSslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/MitmWithEncryptedTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithEncryptedTCPChainedProxyTest.java
@@ -34,6 +34,11 @@ public class MitmWithEncryptedTCPChainedProxyTest extends MitmWithChainedProxyTe
             public SSLEngine newSslEngine() {
                 return sslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return sslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }

--- a/src/test/java/org/littleshoot/proxy/MitmWithEncryptedUDTChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithEncryptedUDTChainedProxyTest.java
@@ -34,6 +34,11 @@ public class MitmWithEncryptedUDTChainedProxyTest extends MitmWithChainedProxyTe
             public SSLEngine newSslEngine() {
                 return sslEngineSource.newSslEngine();
             }
+
+            @Override
+            public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                return sslEngineSource.newSslEngine(peerHost, peerPort);
+            }
         };
     }
 }


### PR DESCRIPTION
Code changes to send SNI headers for outbound proxies and related unit test changes.