### PR TITLE
Add support for making MITMing selective depending on peer host/port

### DIFF
--- a/src/main/java/org/littleshoot/proxy/MitmManager.java
+++ b/src/main/java/org/littleshoot/proxy/MitmManager.java
@@ -1,7 +1,6 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.HttpRequest;
-
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 
@@ -16,7 +15,7 @@ public interface MitmManager {
      *
      * @param peerHost to start a client connection to the server.
      * @param peerPort to start a client connection to the server.
-     * 
+     *
      * @return an SSLEngine used to connect to an upstream server
      */
     SSLEngine serverSslEngine(String peerHost, int peerPort);
@@ -33,13 +32,13 @@ public interface MitmManager {
      * Creates an {@link SSLEngine} for encrypting the client connection based
      * on the given serverSslSession.
      * </p>
-     * 
+     *
      * <p>
      * The serverSslSession is provided in case this method needs to inspect the
      * server's certificates or something else about the encryption on the way
      * to the server.
      * </p>
-     * 
+     *
      * <p>
      * This is the place where one would implement impersonation of the server
      * by issuing replacement certificates signed by the proxy's own

--- a/src/main/java/org/littleshoot/proxy/SelectiveMitmManager.java
+++ b/src/main/java/org/littleshoot/proxy/SelectiveMitmManager.java
@@ -1,0 +1,18 @@
+package org.littleshoot.proxy;
+
+/**
+ * An extension to the {@link MitmManager} interface to allow MITM to be
+ * selectively applied based on the peer. Added as a new interface to not
+ * break existing implementations.
+ */
+public interface SelectiveMitmManager extends MitmManager {
+    /**
+     * Checks if MITM should be applied for a given peer.
+     *
+     * @param peerHost The peer host
+     * @param peerPort The peer port
+     *
+     * @return true to continue with MITM, false to act as if MITM was not enabled for this peer and tunnel raw content.
+     */
+    boolean shouldMITMPeer(String peerHost, int peerPort);
+}

--- a/src/main/java/org/littleshoot/proxy/SelectiveMitmManagerAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/SelectiveMitmManagerAdapter.java
@@ -1,0 +1,31 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.HttpRequest;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+
+/**
+ * Convenience base class for adapting a non-selective-{@link MitmManager} into a {@link SelectiveMitmManager}.
+ */
+public abstract class SelectiveMitmManagerAdapter implements SelectiveMitmManager {
+    private final MitmManager childMitmManager;
+
+    public SelectiveMitmManagerAdapter(MitmManager childMitmManager) {
+        this.childMitmManager = childMitmManager;
+    }
+
+    @Override
+    public SSLEngine serverSslEngine(String peerHost, int peerPort) {
+        return this.childMitmManager.serverSslEngine(peerHost, peerPort);
+    }
+
+    @Override
+    public SSLEngine serverSslEngine() {
+        return this.childMitmManager.serverSslEngine();
+    }
+
+    @Override
+    public SSLEngine clientSslEngineFor(HttpRequest httpRequest, SSLSession serverSslSession) {
+        return this.childMitmManager.clientSslEngineFor(httpRequest, serverSslSession);
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/BaseMitmProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BaseMitmProxyTest.java
@@ -1,0 +1,146 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
+import org.littleshoot.proxy.extras.SelfSignedMitmManager;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Base class for testing a single basic proxy running as a man in the middle.
+ */
+public abstract class BaseMitmProxyTest extends BaseProxyTest {
+    private Set<HttpMethod> requestPreMethodsSeen = new HashSet<HttpMethod>();
+    private Set<HttpMethod> requestPostMethodsSeen = new HashSet<HttpMethod>();
+    private StringBuilder responsePreBody = new StringBuilder();
+    private StringBuilder responsePostBody = new StringBuilder();
+    private Set<HttpMethod> responsePreOriginalRequestMethodsSeen = new HashSet<HttpMethod>();
+    private Set<HttpMethod> responsePostOriginalRequestMethodsSeen = new HashSet<HttpMethod>();
+
+    protected MitmManager getMitmManager() {
+        return new SelfSignedMitmManager();
+    }
+
+    @Override
+    protected void setUp() {
+        this.proxyServer = bootstrapProxy()
+                .withPort(0)
+                .withManInTheMiddle(this.getMitmManager())
+                .withFiltersSource(new HttpFiltersSourceAdapter() {
+                    @Override
+                    public HttpFilters filterRequest(HttpRequest originalRequest) {
+                        return new HttpFiltersAdapter(originalRequest) {
+                            @Override
+                            public HttpResponse clientToProxyRequest(
+                                    HttpObject httpObject) {
+                                if (httpObject instanceof HttpRequest) {
+                                    requestPreMethodsSeen
+                                            .add(((HttpRequest) httpObject)
+                                                    .getMethod());
+                                }
+                                return null;
+                            }
+
+                            @Override
+                            public HttpResponse proxyToServerRequest(
+                                    HttpObject httpObject) {
+                                if (httpObject instanceof HttpRequest) {
+                                    requestPostMethodsSeen
+                                            .add(((HttpRequest) httpObject)
+                                                    .getMethod());
+                                }
+                                return null;
+                            }
+
+                            @Override
+                            public HttpObject serverToProxyResponse(
+                                    HttpObject httpObject) {
+                                if (httpObject instanceof HttpResponse) {
+                                    responsePreOriginalRequestMethodsSeen
+                                            .add(originalRequest.getMethod());
+                                } else if (httpObject instanceof HttpContent) {
+                                    responsePreBody.append(((HttpContent) httpObject)
+                                            .content().toString(
+                                                    Charset.forName("UTF-8")));
+                                }
+                                return httpObject;
+                            }
+
+                            @Override
+                            public HttpObject proxyToClientResponse(
+                                    HttpObject httpObject) {
+                                if (httpObject instanceof HttpResponse) {
+                                    responsePostOriginalRequestMethodsSeen
+                                            .add(originalRequest.getMethod());
+                                } else if (httpObject instanceof HttpContent) {
+                                    responsePostBody.append(((HttpContent) httpObject)
+                                            .content().toString(
+                                                    Charset.forName("UTF-8")));
+                                }
+                                return httpObject;
+                            }
+                        };
+                    }
+                })
+                .start();
+    }
+
+    protected void assertMethodSeenInRequestFilters(HttpMethod method) {
+        assertThat(method
+                        + " should have been seen in clientToProxyRequest filter",
+                requestPreMethodsSeen, hasItem(method));
+        assertThat(method
+                        + " should have been seen in proxyToServerRequest filter",
+                requestPostMethodsSeen, hasItem(method));
+    }
+
+    protected void assertMethodSeenInResponseFilters(HttpMethod method) {
+        assertThat(
+                method
+                        + " should have been seen as the original requests's method in serverToProxyResponse filter",
+                responsePreOriginalRequestMethodsSeen, hasItem(method));
+        assertThat(
+                method
+                        + " should have been seen as the original requests's method in proxyToClientResponse filter",
+                responsePostOriginalRequestMethodsSeen, hasItem(method));
+    }
+
+    protected void assertMethodNotSeenInRequestFilters(HttpMethod method) {
+        assertThat(method
+                        + " should have not been seen in clientToProxyRequest filter",
+                requestPreMethodsSeen, not(hasItem(method)));
+        assertThat(method
+                        + " should have not been seen in proxyToServerRequest filter",
+                requestPostMethodsSeen, not(hasItem(method)));
+    }
+
+    protected void assertMethodNotSeenInResponseFilters(HttpMethod method) {
+        assertThat(
+                method
+                        + " should have not been seen as the original requests's method in serverToProxyResponse filter",
+                responsePreOriginalRequestMethodsSeen, not(hasItem(method)));
+        assertThat(
+                method
+                        + " should have not been seen as the original requests's method in proxyToClientResponse filter",
+                responsePostOriginalRequestMethodsSeen, not(hasItem(method)));
+    }
+
+    protected void assertResponseFromFiltersMatchesActualResponse() {
+        assertEquals(
+                "Data received through HttpFilters.serverToProxyResponse should match response",
+                lastResponse, responsePreBody.toString());
+        assertEquals(
+                "Data received through HttpFilters.proxyToClientResponse should match response",
+                lastResponse, responsePostBody.toString());
+    }
+
+}

--- a/src/test/java/org/littleshoot/proxy/SelectiveMitmProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/SelectiveMitmProxyTest.java
@@ -1,0 +1,83 @@
+package org.littleshoot.proxy;
+
+import com.google.common.net.HostAndPort;
+import io.netty.handler.codec.http.HttpMethod;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.http.HttpHost;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests just a single basic proxy running as a man in the middle, where the
+ *   MTM manager is a selective manager, that for the purpose of the tests, always
+ *   returns false.
+ */
+public class SelectiveMitmProxyTest extends BaseMitmProxyTest {
+    private List<HostAndPort> mitmRequests = new ArrayList<>();
+
+    @Override
+    protected boolean isMITM() {
+        return false;
+    }
+
+    @Override
+    protected MitmManager getMitmManager() {
+        return new SelectiveMitmManagerAdapter(super.getMitmManager()) {
+            @Override
+            public boolean shouldMITMPeer(String peerHost, int peerPort) {
+                mitmRequests.add(HostAndPort.fromParts(peerHost, peerPort));
+                return false;
+            }
+        };
+    }
+
+    @Override
+    public void testSimpleGetRequest() throws Exception {
+        super.testSimpleGetRequest();
+        assertMethodSeenInRequestFilters(HttpMethod.GET);
+        assertMethodSeenInResponseFilters(HttpMethod.GET);
+        assertNoMitmChecks();
+        assertResponseFromFiltersMatchesActualResponse();
+    }
+
+    @Override
+    public void testSimpleGetRequestOverHTTPS() throws Exception {
+        super.testSimpleGetRequestOverHTTPS();
+        assertMethodSeenInRequestFilters(HttpMethod.CONNECT);
+        assertSingleMitmCheck(httpsWebHost);
+        assertMethodNotSeenInRequestFilters(HttpMethod.GET);
+        assertMethodNotSeenInRequestFilters(HttpMethod.GET);
+    }
+
+    @Override
+    public void testSimplePostRequest() throws Exception {
+        super.testSimplePostRequest();
+        assertMethodSeenInRequestFilters(HttpMethod.POST);
+        assertMethodSeenInResponseFilters(HttpMethod.POST);
+        assertNoMitmChecks();
+        assertResponseFromFiltersMatchesActualResponse();
+    }
+
+    @Override
+    public void testSimplePostRequestOverHTTPS() throws Exception {
+        super.testSimplePostRequestOverHTTPS();
+        assertMethodSeenInRequestFilters(HttpMethod.CONNECT);
+        assertSingleMitmCheck(httpsWebHost);
+        assertMethodNotSeenInRequestFilters(HttpMethod.POST);
+        assertMethodNotSeenInRequestFilters(HttpMethod.POST);
+    }
+
+    private void assertNoMitmChecks() {
+        assertThat(mitmRequests, is(empty()));
+    }
+
+    private void assertSingleMitmCheck(HttpHost host) {
+        assertThat(mitmRequests, hasSize(1));
+        assertThat(mitmRequests.get(0), is(equalTo(HostAndPort.fromParts(host.getHostName(), host.getPort()))));
+    }
+}


### PR DESCRIPTION
This is helpful when needing to deal with certificate pinned applications at the same time as the intended MITMable traffic, when both must use the same proxy.

Note: This pull request should be rejected if pull request #402 is merged first. #402 upgrades the java version of this project to 8, at which point it would be better to make shouldMITMPeer a default method inside MitmManager instead of in the extension interface SelectiveMitmManager.