### PR TITLE
Issue 285: Support for chained SOCKS proxies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <netty.version>4.0.44.Final</netty.version>
+        <netty.version>4.1.8.Final</netty.version>
         <slf4j.version>1.7.24</slf4j.version>
         <java.version>1.7</java.version>
     </properties>
@@ -173,13 +173,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <profile>
-            <id>netty-4.1</id>
-            <properties>
-                <netty.version>4.1.8.Final</netty.version>
-            </properties>
-        </profile>
     </profiles>
 
     <dependencies>
@@ -282,6 +275,10 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-example</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.barchart.udt</groupId>
@@ -374,7 +371,24 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-example</artifactId>
+                <version>${netty.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                  <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative</artifactId>
+                  </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
@@ -395,11 +409,6 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-udp</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-example</artifactId>
                 <version>${netty.version}</version>
             </dependency>
         </dependencies>

--- a/src/main/java/org/littleshoot/proxy/ChainedProxy.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxy.java
@@ -40,6 +40,28 @@ public interface ChainedProxy extends SslEngineSource {
     TransportProtocol getTransportProtocol();
 
     /**
+     * Tell LittleProxy the type of chained proxy that it will be
+     * connecting to.  This setting determines what type of requests
+     * LittleProxy will use to communicate with the chained proxy.
+     * @return the chained proxy type.
+     */
+    ChainedProxyType getChainedProxyType();
+
+    /**
+     * (Optional) implement this method if the chained proxy requires
+     * a username.
+     * @return the username to send to the chained proxy.
+     */
+    String getUsername();
+
+    /**
+     * (Optional) implement this method if the chained proxy requires
+     * a password.
+     * @return the password to send to the chained proxy.
+     */
+    String getPassword();
+
+    /**
      * Implement this method to tell LittleProxy whether or not to encrypt
      * connections to the chained proxy for the given request. If true,
      * LittleProxy will call {@link SslEngineSource#newSslEngine()} to obtain an

--- a/src/main/java/org/littleshoot/proxy/ChainedProxyAdapter.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxyAdapter.java
@@ -30,6 +30,21 @@ public class ChainedProxyAdapter implements ChainedProxy {
     public TransportProtocol getTransportProtocol() {
         return TransportProtocol.TCP;
     }
+    
+    @Override
+    public ChainedProxyType getChainedProxyType() {
+        return ChainedProxyType.HTTP;
+    }
+    
+    @Override
+    public String getUsername() {
+        return null;
+    }
+    
+    @Override
+    public String getPassword() {
+        return null;
+    }
 
     @Override
     public boolean requiresEncryption() {

--- a/src/main/java/org/littleshoot/proxy/ChainedProxyType.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxyType.java
@@ -1,0 +1,8 @@
+package org.littleshoot.proxy;
+
+/**
+ * Enumeration of chained proxy types supported by LittleProxy.
+ */
+public enum ChainedProxyType {
+    HTTP, SOCKS4, SOCKS5
+}

--- a/src/main/java/org/littleshoot/proxy/UnknownChainedProxyTypeException.java
+++ b/src/main/java/org/littleshoot/proxy/UnknownChainedProxyTypeException.java
@@ -1,0 +1,13 @@
+package org.littleshoot.proxy;
+
+/**
+ * This exception indicates that the system was asked to use an
+ * {@link ChainedProxyType} that it didn't know how to handle.
+ */
+public class UnknownChainedProxyTypeException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+    
+    public UnknownChainedProxyTypeException(ChainedProxyType chainedProxyType) {
+        super(String.format("Unknown %s: %s", ChainedProxyType.class.getSimpleName(), chainedProxyType));
+    }
+}

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
@@ -43,6 +43,17 @@ class ConnectionFlow {
     }
 
     /**
+     * Add a {@link ConnectionFlowStep} to the beginning of this flow.
+     * 
+     * @param step
+     * @return
+     */
+    ConnectionFlow first(ConnectionFlowStep step) {
+        steps.addFirst(step);
+        return this;
+    }
+
+    /**
      * Add a {@link ConnectionFlowStep} to the end of this flow.
      * 
      * @param step
@@ -50,17 +61,6 @@ class ConnectionFlow {
      */
     ConnectionFlow then(ConnectionFlowStep step) {
         steps.addLast(step);
-        return this;
-    }
-    
-    /**
-     * Add a {@link ConnectionFlowStep} to the beginning of this flow.
-     * 
-     * @param step
-     * @return
-     */
-    ConnectionFlow next(ConnectionFlowStep step) {
-        steps.addFirst(step);
         return this;
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ConnectionFlow.java
@@ -3,8 +3,8 @@ package org.littleshoot.proxy.impl;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
  * Coordinates the various steps involved in establishing a connection, such as
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * processing, and so on.
  */
 class ConnectionFlow {
-    private Queue<ConnectionFlowStep> steps = new ConcurrentLinkedQueue<ConnectionFlowStep>();
+    private Deque<ConnectionFlowStep> steps = new ConcurrentLinkedDeque<ConnectionFlowStep>();
 
     private final ClientToProxyConnection clientConnection;
     private final ProxyToServerConnection serverConnection;
@@ -43,13 +43,24 @@ class ConnectionFlow {
     }
 
     /**
-     * Add a {@link ConnectionFlowStep} to this flow.
+     * Add a {@link ConnectionFlowStep} to the end of this flow.
      * 
      * @param step
      * @return
      */
     ConnectionFlow then(ConnectionFlowStep step) {
-        steps.add(step);
+        steps.addLast(step);
+        return this;
+    }
+    
+    /**
+     * Add a {@link ConnectionFlowStep} to the beginning of this flow.
+     * 
+     * @param step
+     * @return
+     */
+    ConnectionFlow next(ConnectionFlowStep step) {
+        steps.addFirst(step);
         return this;
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -835,12 +835,12 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 final boolean authSuccess;
                 if (selectedAuthMethod == Socks5AuthMethod.NO_AUTH) {
                     // Immediately proceed to SOCKS CONNECT
-                    flow.next(SOCKS5CONNECTRequestWithChainedProxy);
+                    flow.first(SOCKS5CONNECTRequestWithChainedProxy);
                     authSuccess = true;
                 }
                 else if (selectedAuthMethod == Socks5AuthMethod.PASSWORD) {
                     // Insert a password negotiation step:
-                    flow.next(SOCKS5SendPasswordCredentials);
+                    flow.first(SOCKS5SendPasswordCredentials);
                     authSuccess = true;
                 }
                 else {
@@ -881,7 +881,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
         void read(ConnectionFlow flow, Object msg) {
             if (msg instanceof Socks5PasswordAuthResponse) {
                 if (((Socks5PasswordAuthResponse) msg).status() == Socks5PasswordAuthStatus.SUCCESS) {
-                    flow.next(SOCKS5CONNECTRequestWithChainedProxy);
+                    flow.first(SOCKS5CONNECTRequestWithChainedProxy);
                     flow.advance();
                     return;
                 }

--- a/src/test/java/org/littleshoot/proxy/BaseChainedSocksProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BaseChainedSocksProxyTest.java
@@ -1,0 +1,84 @@
+package org.littleshoot.proxy;
+
+import static org.junit.Assert.fail;
+
+import java.net.InetSocketAddress;
+import java.util.Queue;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.example.socksproxy.SocksServerInitializer;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+abstract public class BaseChainedSocksProxyTest extends BaseProxyTest {
+    private EventLoopGroup socksBossGroup;
+    private EventLoopGroup socksWorkerGroup;
+    private int socksPort;
+
+    abstract protected ChainedProxyType getSocksProxyType();
+
+    @Override
+    protected void setUp() throws Exception {
+        initializeSocksServer();
+        this.proxyServer = bootstrapProxy()
+                .withName("Downstream")
+                .withPort(0)
+                .withChainProxyManager(chainedProxyManager())
+                .start();
+    }
+
+    @Override
+    protected void tearDown() {
+        if (socksBossGroup != null) {
+            socksBossGroup.shutdownGracefully();
+        }
+        if (socksWorkerGroup != null) {
+            socksWorkerGroup.shutdownGracefully();
+        }
+    }
+
+    private void initializeSocksServer() throws Exception {
+        socksBossGroup = new NioEventLoopGroup(1);
+        socksWorkerGroup = new NioEventLoopGroup();
+
+        ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(socksBossGroup, socksWorkerGroup)
+         .channel(NioServerSocketChannel.class)
+         .handler(new LoggingHandler(LogLevel.DEBUG))
+         .childHandler(new SocksServerInitializer());
+
+        ChannelFuture channelFuture = bootstrap.bind(0).sync();
+        socksPort = ((InetSocketAddress)channelFuture.channel().localAddress()).getPort();
+    }
+
+    private ChainedProxyManager chainedProxyManager() {
+        return new ChainedProxyManager() {
+            @Override
+            public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies) {
+                chainedProxies.add(new ChainedProxyAdapter() {
+                    @Override
+                    public InetSocketAddress getChainedProxyAddress() {
+                        return new InetSocketAddress("127.0.0.1", socksPort);
+                    }
+                    @Override
+                    public ChainedProxyType getChainedProxyType() {
+                        final ChainedProxyType socksProxyType = getSocksProxyType();
+                        switch (socksProxyType) {
+                            case SOCKS4:
+                            case SOCKS5:
+                                return socksProxyType;
+                            default:
+                                fail(socksProxyType + " is not a type of SOCKS proxy");
+                                throw new IllegalArgumentException(socksProxyType + " is not a type of SOCKS proxy");
+                        }
+                    }
+                });
+            }
+        };
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/BaseChainedSocksProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BaseChainedSocksProxyTest.java
@@ -74,7 +74,7 @@ abstract public class BaseChainedSocksProxyTest extends BaseProxyTest {
                                 return socksProxyType;
                             default:
                                 fail(socksProxyType + " is not a type of SOCKS proxy");
-                                throw new IllegalArgumentException(socksProxyType + " is not a type of SOCKS proxy");
+                                throw new UnknownChainedProxyTypeException(socksProxyType);
                         }
                     }
                 });

--- a/src/test/java/org/littleshoot/proxy/Socks4ChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/Socks4ChainedProxyTest.java
@@ -1,0 +1,8 @@
+package org.littleshoot.proxy;
+
+public class Socks4ChainedProxyTest extends BaseChainedSocksProxyTest {
+    @Override
+    protected ChainedProxyType getSocksProxyType() {
+        return ChainedProxyType.SOCKS4;
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/Socks5ChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/Socks5ChainedProxyTest.java
@@ -1,0 +1,8 @@
+package org.littleshoot.proxy;
+
+public class Socks5ChainedProxyTest extends BaseChainedSocksProxyTest {
+    @Override
+    protected ChainedProxyType getSocksProxyType() {
+        return ChainedProxyType.SOCKS5;
+    }
+}


### PR DESCRIPTION
This change adds support for two additional types of chained upstream proxies: ```SOCKS4``` and ```SOCKS5``` (in addition to the existing ```HTTP``` proxy support).  See related issue here: https://github.com/adamfisk/LittleProxy/issues/285

Users can take advantage of the new SOCKS support by setting some new fields in ```ChainedProxy``` / ```ChainedProxyAdapter```:

* There is a new enum called ```ChainedProxyType``` with possible values { ```HTTP```, ```SOCKS4```, ```SOCKS5``` }
* Username and/or password can be specified for the upstream SOCKS server.  SOCKS4 supports username; SOCKS5 supports username and password

Overall the changes were fairly minor because I was able to take advantage of the built-in SOCKS client support in Netty 4.1.  However, in order to use those new classes I had to change the default Netty version from 4.0 to 4.1 in ```pom.xml```.

All existing unit tests are passing, and wrote new tests for SOCKS4 and SOCKS5 which take advantage of the SOCKS server in the ```netty-example``` module.