### PR TITLE
Switch to openjdk7 for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 
 cache:

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.0</version>
+            <version>23.0-android</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
LittleProxy builds using JDK7 have been failing on Travis-CI since version 1.1.2 released. (builds on JDK8 have been succeeding). It looks like this (https://github.com/travis-ci/travis-ci/issues/7019) is the problem -- oraclejdk7 is no longer available on the "trusty" image.

Best suggestions from that thread seem to be to either switch to openjdk7 or just drop java7 completely.