### PR TITLE
Made client details available to ChainedProxyManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.littleshoot</groupId>
     <artifactId>littleproxy</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.2</version>
+    <version>1.1.2_custom</version>
     <name>LittleProxy</name>
     <description>
         LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.
@@ -50,7 +50,7 @@
         <connection>scm:git:https://adamfisk@github.com/adamfisk/LittleProxy.git</connection>
         <developerConnection>scm:git:git@github.com:adamfisk/LittleProxy</developerConnection>
         <url>scm:git:git@github.com:adamfisk/LittleProxy.git</url>
-        <tag>littleproxy-1.1.2</tag>
+        <tag>littleproxy-1.1.2_custom</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/java/org/littleshoot/proxy/ChainedProxyManager.java
+++ b/src/main/java/org/littleshoot/proxy/ChainedProxyManager.java
@@ -1,6 +1,7 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.HttpRequest;
+import org.littleshoot.proxy.impl.ClientDetails;
 
 import java.util.Queue;
 
@@ -32,7 +33,9 @@ public interface ChainedProxyManager {
      * 
      * @param httpRequest
      * @param chainedProxies
+     * @param clientDetails
      */
     void lookupChainedProxies(HttpRequest httpRequest,
-            Queue<ChainedProxy> chainedProxies);
+                              Queue<ChainedProxy> chainedProxies,
+                              ClientDetails clientDetails);
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ClientDetails.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientDetails.java
@@ -1,0 +1,35 @@
+package org.littleshoot.proxy.impl;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Contains information about the client.
+ */
+public class ClientDetails {
+
+    /**
+     * The user name that was used for authentication, or null if authentication wasn't performed.
+     */
+    private volatile String userName;
+
+    /**
+     * The client's address
+     */
+    private volatile InetSocketAddress clientAddress;
+
+    public String getUserName() {
+        return userName;
+    }
+
+    void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public InetSocketAddress getClientAddress() {
+        return clientAddress;
+    }
+
+    void setClientAddress(InetSocketAddress clientAddress) {
+        this.clientAddress = clientAddress;
+    }
+}

--- a/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ClientToProxyConnection.java
@@ -141,6 +141,8 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
      */
     private volatile HttpRequest currentRequest;
 
+    private final ClientDetails clientDetails = new ClientDetails();
+
     ClientToProxyConnection(
             final DefaultHttpProxyServer proxyServer,
             SslEngineSource sslEngineSource,
@@ -994,6 +996,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
             writeAuthenticationRequired(authenticator.getRealm());
             return true;
         }
+        clientDetails.setUserName(userName);
 
         LOG.debug("Got proxy authorization!");
         // We need to remove the header before sending the request on.
@@ -1402,6 +1405,7 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
     private void recordClientConnected() {
         try {
             InetSocketAddress clientAddress = getClientAddress();
+            clientDetails.setClientAddress(clientAddress);
             for (ActivityTracker tracker : proxyServer
                     .getActivityTrackers()) {
                 tracker.clientConnected(clientAddress);
@@ -1450,6 +1454,10 @@ public class ClientToProxyConnection extends ProxyConnection<HttpRequest> {
         } else {
             return new FlowContext(this);
         }
+    }
+
+    public ClientDetails getClientDetails() {
+        return clientDetails;
     }
 
 }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -161,7 +161,7 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                 .getChainProxyManager();
         if (chainedProxyManager != null) {
             chainedProxyManager.lookupChainedProxies(initialHttpRequest,
-                    chainedProxies);
+                    chainedProxies, clientConnection.getClientDetails());
             if (chainedProxies.size() == 0) {
                 // ChainedProxyManager returned no proxies, can't connect
                 return null;

--- a/src/test/java/org/littleshoot/proxy/AuthenticatingProxyWithChainingTest.java
+++ b/src/test/java/org/littleshoot/proxy/AuthenticatingProxyWithChainingTest.java
@@ -1,0 +1,63 @@
+package org.littleshoot.proxy;
+
+import io.netty.handler.codec.http.HttpRequest;
+import org.junit.Assert;
+import org.littleshoot.proxy.impl.ClientDetails;
+
+import java.util.Queue;
+
+/**
+ * Tests a single proxy that requires username/password authentication.
+ */
+public class AuthenticatingProxyWithChainingTest extends BaseProxyTest
+        implements ProxyAuthenticator, ChainedProxyManager {
+
+    private ClientDetails savedClientDetails;
+
+    @Override
+    protected void setUp() {
+        this.proxyServer = bootstrapProxy()
+                .withPort(0)
+                .withProxyAuthenticator(this)
+                .withChainProxyManager(this)
+                .start();
+    }
+
+    @Override
+    protected String getUsername() {
+        return "user1";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "user2";
+    }
+
+    @Override
+    public boolean authenticate(String userName, String password) {
+        return getUsername().equals(userName) && getPassword().equals(password);
+    }
+
+    @Override
+    protected boolean isAuthenticating() {
+        return true;
+    }
+
+    @Override
+    public String getRealm() {
+        return null;
+    }
+
+    @Override
+    public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies, ClientDetails clientDetails) {
+        savedClientDetails = clientDetails;
+        chainedProxies.add(ChainedProxyAdapter.FALLBACK_TO_DIRECT_CONNECTION);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        Assert.assertEquals(getUsername(), savedClientDetails.getUserName());
+        Assert.assertTrue(savedClientDetails.getClientAddress().getAddress().isLoopbackAddress());
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/BaseChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/BaseChainedProxyTest.java
@@ -1,6 +1,7 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.HttpRequest;
+import org.littleshoot.proxy.impl.ClientDetails;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.net.InetAddress;
@@ -70,7 +71,8 @@ public abstract class BaseChainedProxyTest extends BaseProxyTest {
         return new ChainedProxyManager() {
             @Override
             public void lookupChainedProxies(HttpRequest httpRequest,
-                    Queue<ChainedProxy> chainedProxies) {
+                                             Queue<ChainedProxy> chainedProxies,
+                                             ClientDetails clientDetails) {
                 chainedProxies.add(newChainedProxy());
             }
         };

--- a/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackTest.java
+++ b/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackTest.java
@@ -9,6 +9,7 @@ import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
+import org.littleshoot.proxy.impl.ClientDetails;
 
 /**
  * Tests a proxy chained to a missing downstream proxy. When the downstream
@@ -27,7 +28,8 @@ public class ChainedProxyWithFallbackTest extends BaseProxyTest {
                 .withChainProxyManager(new ChainedProxyManager() {
                     @Override
                     public void lookupChainedProxies(HttpRequest httpRequest,
-                            Queue<ChainedProxy> chainedProxies) {
+                                                     Queue<ChainedProxy> chainedProxies,
+                                                     ClientDetails clientDetails) {
                         chainedProxies.add(new ChainedProxyAdapter() {
                             @Override
                             public InetSocketAddress getChainedProxyAddress() {

--- a/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackToDirectDueToSSLTest.java
+++ b/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackToDirectDueToSSLTest.java
@@ -1,6 +1,7 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.HttpRequest;
+import org.littleshoot.proxy.impl.ClientDetails;
 
 import java.util.Queue;
 
@@ -27,7 +28,8 @@ public class ChainedProxyWithFallbackToDirectDueToSSLTest extends
         return new ChainedProxyManager() {
             @Override
             public void lookupChainedProxies(HttpRequest httpRequest,
-                    Queue<ChainedProxy> chainedProxies) {
+                                             Queue<ChainedProxy> chainedProxies,
+                                             ClientDetails clientDetails) {
                 // This first one has a bad cert
                 chainedProxies.add(newChainedProxy());
                 chainedProxies

--- a/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackToOtherChainedProxyDueToSSLTest.java
+++ b/src/test/java/org/littleshoot/proxy/ChainedProxyWithFallbackToOtherChainedProxyDueToSSLTest.java
@@ -1,6 +1,7 @@
 package org.littleshoot.proxy;
 
 import io.netty.handler.codec.http.HttpRequest;
+import org.littleshoot.proxy.impl.ClientDetails;
 
 import java.util.Queue;
 
@@ -22,7 +23,8 @@ public class ChainedProxyWithFallbackToOtherChainedProxyDueToSSLTest extends
         return new ChainedProxyManager() {
             @Override
             public void lookupChainedProxies(HttpRequest httpRequest,
-                    Queue<ChainedProxy> chainedProxies) {
+                                             Queue<ChainedProxy> chainedProxies,
+                                             ClientDetails clientDetails) {
                 // This first one has a bad cert
                 chainedProxies.add(newChainedProxy());
                 // This 2nd one should work

--- a/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
+++ b/src/test/java/org/littleshoot/proxy/HttpFilterTest.java
@@ -14,6 +14,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
+import org.littleshoot.proxy.impl.ClientDetails;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.littleshoot.proxy.test.HttpClientUtil;
 import org.mockserver.integration.ClientAndServer;
@@ -548,7 +549,7 @@ public class HttpFilterTest {
                 .withFiltersSource(filtersSource)
                 .withChainProxyManager(new ChainedProxyManager() {
                     @Override
-                    public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies) {
+                    public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies, ClientDetails clientDetails) {
                         chainedProxies.add(new ChainedProxyAdapter() {
                             @Override
                             public InetSocketAddress getChainedProxyAddress() {
@@ -616,7 +617,7 @@ public class HttpFilterTest {
                 .withFiltersSource(filtersSource)
                 .withChainProxyManager(new ChainedProxyManager() {
                     @Override
-                    public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies) {
+                    public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies, ClientDetails clientDetails) {
                         chainedProxies.add(new ChainedProxyAdapter() {
                             @Override
                             public InetSocketAddress getChainedProxyAddress() {

--- a/src/test/java/org/littleshoot/proxy/NoChainedProxiesTest.java
+++ b/src/test/java/org/littleshoot/proxy/NoChainedProxiesTest.java
@@ -5,6 +5,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import java.util.Queue;
 
 import org.junit.Test;
+import org.littleshoot.proxy.impl.ClientDetails;
 
 /**
  * Tests that when there are no chained proxies, we get a bad gateway.
@@ -17,7 +18,8 @@ public class NoChainedProxiesTest extends AbstractProxyTest {
                 .withChainProxyManager(new ChainedProxyManager() {
                     @Override
                     public void lookupChainedProxies(HttpRequest httpRequest,
-                            Queue<ChainedProxy> chainedProxies) {
+                                                     Queue<ChainedProxy> chainedProxies,
+                                                     ClientDetails clientDetails) {
                         // Leave list empty
                     }
                 })


### PR DESCRIPTION
Give ChainedAccessManager access to information about the client so it can behave differently for different users.  See issue #422.