### PR TITLE
Fix git URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ LittleProxy is a high performance HTTP proxy written in Java atop Trustin Lee's 
 One option is to clone LittleProxy and run it from the command line. This is as simple as:
 
 ```
-$ git clone git://github.com/adamfisk/LittleProxy.git
+$ git clone https://github.com/adamfisk/LittleProxy.git
 $ cd LittleProxy
 $ ./run.bash
 ```


### PR DESCRIPTION
Fix the error:

```
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```