### PR TITLE
bump netty and guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
-        <netty.version>4.0.44.Final</netty.version>
+        <netty.version>4.1.42.Final</netty.version>
         <slf4j.version>1.7.24</slf4j.version>
         <java.version>1.7</java.version>
     </properties>
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.0</version>
+            <version>30.0-jre</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bump Netty version - https://github.com/advisories/GHSA-p979-4mfw-53vg
Bump Guava version - https://github.com/advisories/GHSA-mvr2-9pj6-7w5j
Seems like the code has been refactored to remove the deprecated method from Guava