### PR TITLE
Update README to warn that the project is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+| :warning:  This is project is no longer maintained   |
+|------------------------------------------------------|
+
 [![Build Status](https://travis-ci.org/adamfisk/LittleProxy.png?branch=master)](https://travis-ci.org/adamfisk/LittleProxy)
 
 LittleProxy is a high performance HTTP proxy written in Java atop Trustin Lee's excellent [Netty](http://netty.io) event-based networking library. It's quite stable, performs well, and is easy to integrate into your projects. 


### PR DESCRIPTION
I have started using the LittleProxy to then realize that I am stuck with some old issues that won't be fixed because the project is no longer maintained.

I think we should warn people in the README so they can avoid using the project.